### PR TITLE
Data.List.nub is O(n^2); replaced it with an equivalent O(n*log(n)) version

### DIFF
--- a/ghcid.cabal
+++ b/ghcid.cabal
@@ -32,7 +32,8 @@ library
         directory,
         extra >= 0.4,
         process >= 1.1,
-        cmdargs >= 0.10
+        cmdargs >= 0.10,
+        containers >= 0.5
   if !os(windows)
     build-depends: terminal-size >= 0.2.1
   other-modules:   

--- a/src/Language/Haskell/Ghcid/Parser.hs
+++ b/src/Language/Haskell/Ghcid/Parser.hs
@@ -11,6 +11,8 @@ import System.FilePath
 import Data.Char
 import Data.List
 
+import qualified Data.Set as Set
+
 import Language.Haskell.Ghcid.Types
 
 -- | Parse messages from show modules command
@@ -22,7 +24,7 @@ parseShowModules xs =
 -- | Parse messages given on reload
 -- nub, because cabal repl sometimes does two reloads at the start
 parseLoad :: [String] -> [Load]
-parseLoad  = nub . parseLoad'            
+parseLoad  = ordNub . parseLoad'            
 
 -- | Parse messages given on reload
 parseLoad' :: [String] -> [Load]
@@ -41,3 +43,14 @@ parseLoad' (x:xs)
     = Message sev file (p1,p2) (x:msg) : parseLoad las
 parseLoad' (_:xs) = parseLoad xs
 parseLoad' [] = []
+
+-- ordNub function from <https://github.com/nh2/haskell-ordnub>
+-- this *really* ought to be in the standard library, but isn't
+ordNub :: (Ord a) => [a] -> [a]
+ordNub l = go Set.empty l
+  where
+    go _ [] = []
+    go s (x:xs) =
+      if x `Set.member` s
+        then go s xs
+        else x : go (Set.insert x s) xs

--- a/src/Language/Haskell/Ghcid/Types.hs
+++ b/src/Language/Haskell/Ghcid/Types.hs
@@ -29,7 +29,7 @@ data Load
         ,loadFilePos :: (Int,Int)
         ,loadMessage :: [String]
         }
-      deriving (Show,Eq)
+      deriving (Show, Eq, Ord)
       
 -- | Is a Load a message with severity?
 isMessage :: Load -> Bool


### PR DESCRIPTION
If the number of lines to be parsed is long, this will prevent parsing from being unnecessarily sluggish.

Obnoxiously, this version of nub is not in the standard library, and arguably, `nub` and its other O(n^2) `Eq`-only friends ought not to be in `Data.List` to begin with, as they're so seldom what you really want.
