### PR TITLE
Inotify

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,6 +1,5 @@
 :set -fwarn-unused-binds -fwarn-unused-imports
-:set -isrc -itest
-:load Ghcid src\Paths.hs Test
+:set -isrc -itest -idist/build/autogen
 :def docs_ const $ return $ unlines [":!cabal haddock"]
 :def docs const $ return $ unlines [":docs_",":!start dist\\doc\\html\\ghcid\\Language-Haskell-Ghcid.html"]
 :def test const $ return $ unlines ["Test.main"]

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.dist-buildwrapper
 /.project
 /cabal.sandbox.config
+/tags
+/.cabal-sandbox

--- a/ghcid.cabal
+++ b/ghcid.cabal
@@ -57,6 +57,7 @@ executable ghcid
       process >= 1.1,
       cmdargs >= 0.10,
       ansi-terminal,
+      hinotify,
       terminal-size >= 0.3
   other-modules:   
                    Language.Haskell.Ghcid.Types,


### PR DESCRIPTION
So I took a stab at using inotify to watch files. This is a bit of a mess; it took me a while to realize that the add watch function _wasn't_ blocking. So I forked it off on a Haskell thread, but this then raises the question of what happens to all the other watches; I don't know how strong `withINotify` is, but it probably needs to be managed by an Async, etc.

Anyway, this is obviously Linux specific but handles watching a list of files. If you were to refactor the code to want to watch a list of _directories_ then you could use **fsnotify** pretty much as-is (and it has a polling mode for platforms without inotify/kpoll/whaver). 

Anyway, a patch in the spirit of "here's something, I'm sure you can do better; either way all the best"

AfC