### PR TITLE
First attempt at testing automatically after a successful reload

### DIFF
--- a/ghcid.cabal
+++ b/ghcid.cabal
@@ -94,3 +94,30 @@ test-suite ghcid_test
                    Language.Haskell.Ghcid.HighLevelTests,
                    Language.Haskell.Ghcid.UtilTest,
                    Language.Haskell.Ghcid.PollingTest
+
+test-suite ghcid_fasttest
+  type:            exitcode-stdio-1.0
+  ghc-options:     -rtsopts -main-is Test.main -threaded
+  default-language: Haskell2010  
+  build-depends:   
+    base >= 4,
+    filepath,
+    time,
+    directory,
+    process,
+    containers,
+    fsnotify,
+    extra >= 1.1,
+    ansi-terminal,
+    cmdargs,
+    tasty,
+    tasty-hunit
+  if !os(windows)
+    build-depends: terminal-size >= 0.2.1
+  hs-source-dirs:  test, src
+  main-is:         FastTest.hs
+  other-modules:
+                    Language.Haskell.Ghcid.ParserTest,
+                    Language.Haskell.Ghcid.HighLevelTests,
+                    Language.Haskell.Ghcid.UtilTest,
+                    Language.Haskell.Ghcid.PollingTest

--- a/src/Language/Haskell/Ghcid.hs
+++ b/src/Language/Haskell/Ghcid.hs
@@ -8,6 +8,7 @@ module Language.Haskell.Ghcid
  , startGhci
  , showModules
  , reload
+ , runTests
  , exec
  , stopGhci
  )
@@ -82,6 +83,10 @@ showModules ghci = fmap parseShowModules $ exec ghci ":show modules"
 -- | reload modules
 reload :: Ghci -> IO [Load]
 reload ghci = fmap parseLoad $ exec ghci ":reload"
+
+-- | run the test command
+runTests :: String -> Ghci -> IO [String]
+runTests cmd ghci = exec ghci cmd
 
 -- | Stop GHCi
 stopGhci :: Ghci -> IO ()

--- a/src/Language/Haskell/Ghcid/Util.hs
+++ b/src/Language/Haskell/Ghcid/Util.hs
@@ -41,7 +41,7 @@ outStrLn s = outStr $ s ++ "\n"
 
 
 -- | The message to show when no errors have been reported
-allGoodMessage :: String      
+allGoodMessage :: String
 allGoodMessage = "All good"
 
 -- | Like chunksOf, but deal with words up to some gap.

--- a/test/FastTest.hs
+++ b/test/FastTest.hs
@@ -1,0 +1,18 @@
+module Test(main) where
+
+import Test.Tasty
+import Language.Haskell.Ghcid.ParserTest (parserTests)
+import Language.Haskell.Ghcid.HighLevelTests (highLevelTests)
+import Language.Haskell.Ghcid.UtilTest (utilsTests)
+import Language.Haskell.Ghcid.PollingTest (pollingTest)
+
+main :: IO()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "Tests" 
+  [ utilsTests
+  , parserTests
+  --, highLevelTests -- too slow!
+  --, pollingTest   -- too slow!
+  ]

--- a/test/Language/Haskell/Ghcid/PollingTest.hs
+++ b/test/Language/Haskell/Ghcid/PollingTest.hs
@@ -44,13 +44,13 @@ pollingTest  = testCase "Scripted Test" $ do
         try_ $ system "chmod og-w . .ghci"
 
         withWaiterPoll $ \waiter -> bracket (
-          forkIO $ runGhcid waiter [] "ghci" (return (100, 50)) $ \msg ->
+          forkIO $ runGhcid waiter [] "ghci" Nothing (return (100, 50)) $ \msg ->
             unless (isLoading $ map snd msg) $ putMVarNow ref $ map snd msg
-          ) killThread $ \_ -> do    
+          ) killThread $ \_ -> do
             require requireAllGood
             testScript require
             outStrLn "\nSuccess"
-        
+
 isLoading :: [String] -> Bool
 isLoading xs = listToMaybe xs `elem` [Just "Reloading...",Just "Loading..."]
 


### PR DESCRIPTION
This is rough and probably shouldn't yet be merged.

Use with something like: `ghcid --command="cabal repl ghcid_fasttest" --testcommand="main"`

Wishlist / more features:

- [ ] Render test output nicer
- [ ] Interrupt (?) test output on file save
- [ ] Stream test output
- [ ] Interpret exit code perhaps? Fold a successful test run back into "All good"
