### PR TITLE
Change icons depending on number of errors

### DIFF
--- a/ghcid.cabal
+++ b/ghcid.cabal
@@ -33,8 +33,9 @@ library
         extra >= 1.2,
         process >= 1.1,
         cmdargs >= 0.10,
-        terminal-size >= 0.3,
-        Win32
+        terminal-size >= 0.3
+  if os(windows)
+    build-depends: Win32
   other-modules:   
                    Paths_ghcid,
                    Language.Haskell.Ghcid.Types,
@@ -59,8 +60,9 @@ executable ghcid
       process >= 1.1,
       cmdargs >= 0.10,
       ansi-terminal,
-      terminal-size >= 0.3,
-      Win32
+      terminal-size >= 0.3
+  if os(windows)
+    build-depends: Win32
   other-modules:   
                    Language.Haskell.Ghcid.Types,
                    Language.Haskell.Ghcid.Parser,
@@ -86,8 +88,9 @@ test-suite ghcid_test
     terminal-size >= 0.3,
     cmdargs,
     tasty,
-    tasty-hunit,
-    Win32
+    tasty-hunit
+  if os(windows)
+    build-depends: Win32
   hs-source-dirs:  src
   main-is:         Test.hs
   other-modules:   

--- a/ghcid.cabal
+++ b/ghcid.cabal
@@ -84,7 +84,8 @@ test-suite ghcid_test
     terminal-size >= 0.3,
     cmdargs,
     tasty,
-    tasty-hunit
+    tasty-hunit,
+    Win32
   hs-source-dirs:  src
   main-is:         Test.hs
   other-modules:   

--- a/ghcid.cabal
+++ b/ghcid.cabal
@@ -33,7 +33,8 @@ library
         extra >= 1.2,
         process >= 1.1,
         cmdargs >= 0.10,
-        terminal-size >= 0.3
+        terminal-size >= 0.3,
+        Win32
   other-modules:   
                    Paths_ghcid,
                    Language.Haskell.Ghcid.Types,
@@ -58,7 +59,8 @@ executable ghcid
       process >= 1.1,
       cmdargs >= 0.10,
       ansi-terminal,
-      terminal-size >= 0.3
+      terminal-size >= 0.3,
+      Win32
   other-modules:   
                    Language.Haskell.Ghcid.Types,
                    Language.Haskell.Ghcid.Parser,

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -133,13 +133,15 @@ runGhcid waiter restart command outputfiles test size output = do
             messages <- return $ messages ++ filter validWarn warnings
             let (countErrors, countWarnings) = both sum $ unzip [if loadSeverity m == Error then (1,0) else (0,1) | m@Message{} <- messages]
             test <- return $ if countErrors == 0 then test else Nothing
+            
+            changeWindowIcon countWarnings countErrors --defined in src\Language\Haskell\Ghcid\terminal.hs. Like setTitle, but updates the 
 
             let updateTitle extra = setTitle $
                     let f n msg = if n == 0 then "" else show n ++ " " ++ msg ++ ['s' | n > 1]
                     in (if countErrors == 0 && countWarnings == 0 then allGoodMessage else f countErrors "error" ++
                         (if countErrors > 0 && countWarnings > 0 then ", " else "") ++ f countWarnings "warning") ++
                        " " ++ extra ++ "- " ++ takeFileName curdir
-
+        
             updateTitle $ if isJust test then "(running test) " else ""
             outputFill (Just messages) ["Running test..." | isJust test]
             forM_ outputfiles $ \file ->

--- a/src/Language/Haskell/Ghcid/Terminal.hs
+++ b/src/Language/Haskell/Ghcid/Terminal.hs
@@ -1,12 +1,20 @@
 {-# LANGUAGE CPP #-}
 module Language.Haskell.Ghcid.Terminal(
-    terminalTopmost
+    terminalTopmost,
+    changeWindowIcon
     ) where
 
 #if defined(mingw32_HOST_OS)
 import Data.Word
 import Data.Bits
 import Foreign.Ptr
+
+import Graphics.Win32.Misc
+import Graphics.Win32.Window 
+import Graphics.Win32.Message
+import Graphics.Win32.GDI.Types hiding (HWND)
+import System.Win32.Types
+import Unsafe.Coerce
 
 type HWND = Ptr ()
 
@@ -31,4 +39,34 @@ terminalTopmost = do
     return ()
 #else
 terminalTopmost = return ()
+#endif
+
+
+-- | Change the window icon to green, yellow or red depending on whether the file was errorless, contained only warnings or contained at least one error.
+changeWindowIcon :: (Ord a, Num a) => a -> a -> IO ()
+#if defined(mingw32_HOST_OS)
+changeWindowIcon numWarnings numErrors
+    | numErrors   > 0   = getIcon iDI_HAND          >>= setIcon
+    | numWarnings > 0   = getIcon iDI_EXCLAMATION   >>= setIcon
+    | otherwise         = getIcon iDI_ASTERISK      >>= setIcon
+
+    
+wM_SETICON :: WindowMessage
+wM_SETICON = 0x0080
+
+-- | Wrapper around loadIcon from the win32 library.
+getIcon :: Icon -> IO HICON
+getIcon = loadIcon Nothing
+
+-- | Sets the icon of the invoking (console) window to the supplied HICON.
+setIcon :: HICON -> IO ()
+setIcon icon = do
+    wnd <- c_GetConsoleWindow
+    sendMessage wnd wM_SETICON 0 (unsafeCoerce icon) --the 0 indicates the icon in the screen. unsafeCoerce is used to unwrap several newtype layers (HICON -> HANDLE -> DWORD -> LONG)
+    sendMessage wnd wM_SETICON 1 (unsafeCoerce icon) --the 1 indicates the icon in the taskbar and the alt-tab screen
+    return () --discard the result of the sendMessage calls
+    --only works if the application is not pinned to the taskbar (unlikely for ghcid?)
+    
+#else
+changeWindowIcon _ _ = return ()
 #endif


### PR DESCRIPTION
Fix for issue #35. Has some minor issues like not changing the icon back if you kill ghcid with ctrl-c, but nothing major that I could find. 

I added a conditional dependency on Win32 for windows users and kept all code within CPP blocks, so it should only affect windows users. I tested it on a linux box and it still builds fine there.