### PR TITLE
Suppress status messages flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /.project
 /cabal.sandbox.config
 tags
-/tags
 /.cabal-sandbox
 /.stack-work
 # Use 'stack init' on a fresh checkout to generate your own stack.yaml file

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.dist-buildwrapper
 /.project
 /cabal.sandbox.config
+tags
 /tags
 /.cabal-sandbox
 /.stack-work

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -53,7 +53,7 @@ options = cmdArgsMode $ Options
     ,arguments = [] &= args &= typ "MODULE"
     ,test = Nothing &= name "T" &= typ "EXPR" &= help "Command to run after successful loading"
     ,warnings = False &= name "W" &= help "Allow tests to run even with warnings"
-    ,nostatus = False &= name "S" &= help "Suppress status messages"
+    ,nostatus = False &= name "S" &= explicit &= name "no-status" &= help "Suppress status messages"
     ,height = Nothing &= help "Number of lines to use (defaults to console height)"
     ,width = Nothing &= name "w" &= help "Number of columns to use (defaults to console width)"
     ,topmost = False &= name "t" &= help "Set window topmost (Windows only)"

--- a/src/Test/Polling.hs
+++ b/src/Test/Polling.hs
@@ -42,7 +42,7 @@ pollingTest  = testCase "Scripted Test" $ do
         try_ $ system "chmod og-w . .ghci"
 
         withSession $ \session -> withWaiterPoll $ \waiter -> bracket (
-          forkIO $ runGhcid session waiter [] [] "ghci" [] Nothing False (return (100, 50)) False $ \msg ->
+          forkIO $ runGhcid session waiter [] [] "ghci" [] Nothing False False (return (100, 50)) False $ \msg ->
             unless (isLoading $ map snd msg) $ putMVarNow ref $ map snd msg
           ) killThread $ \_ -> do
             require requireAllGood


### PR DESCRIPTION
I have autosave turned on in my editor. ghcid works great, however the constant flickering whenever a file is autosaved is really distracting, especially with many warnings filling the screen.

This option disables the `"Reloading..."` messages that clear the screen and cause the flickering.