### PR TITLE
parse correctly messages with spans

### DIFF
--- a/src/Language/Haskell/Ghcid/Parser.hs
+++ b/src/Language/Haskell/Ghcid/Parser.hs
@@ -36,8 +36,10 @@ parseLoad  = nubOrd . f
             | not $ " " `isPrefixOf` x
             , Just (file,rest) <- breakFileColon x
             , takeExtension file `elem` [".hs",".lhs",".hs-boot",".lhs-boot"]
-            , (pos,rest) <- span (\c -> c == ':' || isDigit c) rest
-            , [p1,p2] <- map read $ words $ map (\c -> if c == ':' then ' ' else c) pos
+             -- take position, including span if present
+            , (pos,rest) <- span (\c -> c == ':' || c == '-' || isDigit c) rest
+            -- separate line and column, ignoring span (we want the start point only)
+            , [p1,p2] <- map read $ words $ map (\c -> if c == ':' then ' ' else c) $ takeWhile (\c->c /= '-') pos 
             , (msg,las) <- span (isPrefixOf " ") xs
             , rest <- trimStart $ unwords $ rest : xs
             , sev <- if "warning:" `isPrefixOf` lower rest then Warning else Error

--- a/src/Test/Parser.hs
+++ b/src/Test/Parser.hs
@@ -12,6 +12,7 @@ parserTests :: TestTree
 parserTests = testGroup "Parser tests"
     [testParseShowModules
     ,testParseLoad
+    ,testParseLoadSpans
     ]
 
 testParseShowModules :: TestTree
@@ -50,4 +51,34 @@ testParseLoad = testCase "Load Parsing" $ parseLoad
     ,Message {loadSeverity = Warning, loadFile = "C:\\GHCi.hs", loadFilePos = (82,1), loadMessage = ["C:\\GHCi.hs:82:1: warning: Defined but not used: \8216foo\8217"]}
     ,Message {loadSeverity = Warning, loadFile = "src\\Haskell.hs", loadFilePos = (4,23), loadMessage = ["src\\Haskell.hs:4:23:","    Warning: {-# SOURCE #-} unnecessary in import of  `Boot'"]}
     ,Message {loadSeverity = Error, loadFile = "src\\Boot.hs-boot", loadFilePos = (2,8), loadMessage = ["src\\Boot.hs-boot:2:8:","    File name does not match module name:","    Saw: `BootX'","    Expected: `Boot'"]}
+    ]
+
+-- | Test when error messages include spans (-ferror-spans)
+testParseLoadSpans :: TestTree
+testParseLoadSpans = testCase "Load Parsing when -ferror-spans is enabled" $ parseLoad
+    ["[1 of 2] Compiling GHCi             ( GHCi.hs, interpreted )"
+    ,"GHCi.hs:70:1-2: Parse error: naked expression at top level"
+    ,"GHCi.hs:72:13-14:"
+    ,"    No instance for (Num ([String] -> [String]))"
+    ,"      arising from the literal `1'"
+    ,"    Possible fix:"
+    ,"      add an instance declaration for (Num ([String] -> [String]))"
+    ,"    In the expression: 1"
+    ,"    In an equation for `parseLoad': parseLoad = 1"
+    ,"GHCi.hs:81:1-15: Warning: Defined but not used: `foo'"
+    ,"C:\\GHCi.hs:82:1-17: warning: Defined but not used: \8216foo\8217" -- GHC 7.12 uses lowercase
+    ,"src\\Haskell.hs:4:23-24:"
+    ,"    Warning: {-# SOURCE #-} unnecessary in import of  `Boot'"
+    ,"src\\Boot.hs-boot:2:8-5:"
+    ,"    File name does not match module name:"
+    ,"    Saw: `BootX'"
+    ,"    Expected: `Boot'"
+    ] @?=
+    [Loading "GHCi" "GHCi.hs"
+    ,Message {loadSeverity = Error, loadFile = "GHCi.hs", loadFilePos = (70,1), loadMessage = ["GHCi.hs:70:1-2: Parse error: naked expression at top level"]}
+    ,Message {loadSeverity = Error, loadFile = "GHCi.hs", loadFilePos = (72,13), loadMessage = ["GHCi.hs:72:13-14:","    No instance for (Num ([String] -> [String]))","      arising from the literal `1'","    Possible fix:","      add an instance declaration for (Num ([String] -> [String]))","    In the expression: 1","    In an equation for `parseLoad': parseLoad = 1"]}
+    ,Message {loadSeverity = Warning, loadFile = "GHCi.hs", loadFilePos = (81,1), loadMessage = ["GHCi.hs:81:1-15: Warning: Defined but not used: `foo'"]}
+    ,Message {loadSeverity = Warning, loadFile = "C:\\GHCi.hs", loadFilePos = (82,1), loadMessage = ["C:\\GHCi.hs:82:1-17: warning: Defined but not used: \8216foo\8217"]}
+    ,Message {loadSeverity = Warning, loadFile = "src\\Haskell.hs", loadFilePos = (4,23), loadMessage = ["src\\Haskell.hs:4:23-24:","    Warning: {-# SOURCE #-} unnecessary in import of  `Boot'"]}
+    ,Message {loadSeverity = Error, loadFile = "src\\Boot.hs-boot", loadFilePos = (2,8), loadMessage = ["src\\Boot.hs-boot:2:8-5:","    File name does not match module name:","    Saw: `BootX'","    Expected: `Boot'"]}
     ]


### PR DESCRIPTION
When -ferrors-spans is set, the message parsing does not include the end column in the position parsing, which means warnings are not properly identifier and are marked as errors. This fixes it (with test added to prove it!).