### PR TITLE
Fix typo in vundle configuration instructions

### DIFF
--- a/plugins/nvim/README.md
+++ b/plugins/nvim/README.md
@@ -23,7 +23,7 @@ also a lot simpler.
 
   For vundle, add the following:
 
-      Plugin 'ndmitchell/ghcid', { 'rtp': 'plugins/vim/' }
+      Plugin 'ndmitchell/ghcid', { 'rtp': 'plugins/nvim' }
 
   Then run `:PluginInstall`.
 


### PR DESCRIPTION
Fix a typo in the vundle configuration instructions