### PR TITLE
Ghc 8.2 formats error messages differently

### DIFF
--- a/src/Language/Haskell/Ghcid/Parser.hs
+++ b/src/Language/Haskell/Ghcid/Parser.hs
@@ -40,7 +40,7 @@ parseLoad  = nubOrd . f
             , (pos,rest) <- span (\c -> c == ':' || c == '-' || isSpan c || isDigit c) rest
             -- separate line and column, ignoring span (we want the start point only)
             , [p1,p2] <- map read $ wordsBy (\c -> c == ':' || isSpan c) $ takeWhile (/= '-') pos
-            , (msg,las) <- span (isPrefixOf " ") xs
+            , (msg,las) <- span isMessageBody xs
             , rest <- trimStart $ unwords $ rest : xs
             , sev <- if "warning:" `isPrefixOf` lower rest then Warning else Error
             = Message sev file (p1,p2) (x:msg) : f las
@@ -57,6 +57,12 @@ parseLoad  = nubOrd . f
         f (_:xs) = f xs
         f [] = []
         isSpan c = c== ',' || c == '(' || c == ')'
+
+-- After the file location, message bodies are indented (perhaps prefixed by a line number)
+isMessageBody :: String -> Bool
+isMessageBody xs = isPrefixOf " " xs || case break (=='|') xs of
+  (prefix, (_:_)) | all (\x -> isSpace x || isDigit x) prefix -> True
+  _ -> False
 
 -- A filename, followed by a colon - be careful to handle Windows drive letters, see #61
 breakFileColon :: String -> Maybe (FilePath, String)

--- a/src/Test/Parser.hs
+++ b/src/Test/Parser.hs
@@ -12,6 +12,7 @@ parserTests :: TestTree
 parserTests = testGroup "Parser tests"
     [testParseShowModules
     ,testParseLoad
+    ,testParseLoadGhc82
     ,testParseLoadSpans
     ]
 
@@ -51,6 +52,18 @@ testParseLoad = testCase "Load Parsing" $ parseLoad
     ,Message {loadSeverity = Warning, loadFile = "C:\\GHCi.hs", loadFilePos = (82,1), loadMessage = ["C:\\GHCi.hs:82:1: warning: Defined but not used: \8216foo\8217"]}
     ,Message {loadSeverity = Warning, loadFile = "src\\Haskell.hs", loadFilePos = (4,23), loadMessage = ["src\\Haskell.hs:4:23:","    Warning: {-# SOURCE #-} unnecessary in import of  `Boot'"]}
     ,Message {loadSeverity = Error, loadFile = "src\\Boot.hs-boot", loadFilePos = (2,8), loadMessage = ["src\\Boot.hs-boot:2:8:","    File name does not match module name:","    Saw: `BootX'","    Expected: `Boot'"]}
+    ]
+
+testParseLoadGhc82 :: TestTree
+testParseLoadGhc82 = testCase "GHC 8.2 Load Parsing" $ parseLoad
+    ["[18 of 24] Compiling Physics ( Physics.hs, interpreted )"
+    ,"Physics.hs:30:18: error: parse error on input ‘^*’"
+    ,"   |"
+    ,"30 |           dx = ' ^* delta"
+    ,"   |                  ^^"
+    ] @?=
+    [Loading "Physics" "Physics.hs"
+    ,Message {loadSeverity = Error, loadFile = "Physics.hs", loadFilePos = (30,18), loadMessage = ["Physics.hs:30:18: error: parse error on input ‘^*’" ,"   |" ,"30 |           dx = ' ^* delta" ,"   |                  ^^"]}
     ]
 
 -- | Test when error messages include spans (-ferror-spans)


### PR DESCRIPTION
Previously, messages would be entirely whitespace indented.
Now, one of the indented lines may be prefixed by a line number, which
should no longer be recognized as the start of a new message.