### PR TITLE
update vscode plugin README

### DIFF
--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -20,5 +20,6 @@ Requires ghcid and a lot of tedious manual setup (the steps above).
 Run:
 
     npm install
-    vsce package
-    code --install-extension haskell-ghcid-0.0.1.vsix
+    node install vsce
+    ./node_modules/vsce/out/vsce package
+    code --install-extension haskell-ghcid-*.vsix


### PR DESCRIPTION
Added steps I needed to successfully perform a local installation over here -

* Installing `vsce` and using it from installed location
* Outdated plugin version number. Replaced with `*` to require less maintainence.