### PR TITLE
vscode plugin handles GHC 8.2 error messages

### DIFF
--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -2,7 +2,7 @@
     "name": "haskell-ghcid",
     "displayName": "haskell-ghcid",
     "description": "Integrate ghcid into VS Code",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publisher": "ndmitchell",
     "homepage": "https://github.com/ndmitchell/ghcid",
     "author": "Neil Mitchell",

--- a/plugins/vscode/src/extension.ts
+++ b/plugins/vscode/src/extension.ts
@@ -13,12 +13,22 @@ export function parseGhcidOutput(dir : string, s : string) : [vscode.Uri, vscode
         return s.replace('\r','').split('\n').filter(x => x != "");
     }
 
-    // split into separate error messages, which all start at col 0 (no spaces)
+    // After the file location, message bodies are indented (perhaps prefixed by a line number)
+    function isMessageBody(x : string) {
+        if (x.startsWith(" "))
+            return true;
+        let sep = x.indexOf('|');
+        if (sep == -1)
+            return false;
+        return !isNaN(Number(x.substr(0, sep)));
+    }
+
+    // split into separate error messages, which all start at col 0 (no spaces) and are following by message bodies
     function split(xs : string[]) : string[][] {
         var cont = [];
         var res = [];
         for (let x of xs) {
-            if (x.startsWith(" "))
+            if (isMessageBody(x))
                 cont.push(x);
             else {
                 if (cont.length > 0) res.push(cont);


### PR DESCRIPTION
Similar to https://github.com/ndmitchell/ghcid/pull/103 -
GHC 8.2's error messages have changed and the vscode plugin needs to be updated or it doesn't properly produce the errors.

An alternative to this approach would be to leave the plugin unchanged but modify `ghcid`'s output so it looks different than GHC's in that the errors are all indented.