### PR TITLE
improve vscode extension README

### DIFF
--- a/plugins/vscode/README.md
+++ b/plugins/vscode/README.md
@@ -22,4 +22,5 @@ Run:
     npm install
     npm install -g vsce
     vsce package
+    rm haskell-ghcid-*.vsix
     code --install-extension haskell-ghcid-*.vsix


### PR DESCRIPTION
current instructions may cause to install older locally built versions (my bad..) that were left in the folder