### PR TITLE
Remove unnecessary Watch Ghcid output command

### DIFF
--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -16,16 +16,11 @@
     },
     "categories": ["Languages", "Linters"],
     "activationEvents": [
-        "onCommand:extension.watchGhcidOutput",
         "onCommand:extension.startGhcid"
     ],
     "main": "./out/src/extension",
     "contributes": {
         "commands": [
-            {
-                "command": "extension.watchGhcidOutput",
-                "title": "Watch Ghcid output"
-            },
             {
                 "command": "extension.startGhcid",
                 "title": "Start Ghcid"

--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -25,7 +25,17 @@
                 "command": "extension.startGhcid",
                 "title": "Start Ghcid"
             }
-        ]
+        ],
+        "configuration": {
+            "title": "Ghcid configuration",
+            "properties": {
+                "ghcid.command": {
+                    "type": "string",
+                    "default": "ghcid",
+                    "description": "Ghcid command"
+                }
+            }
+        }
     },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",

--- a/plugins/vscode/src/extension.ts
+++ b/plugins/vscode/src/extension.ts
@@ -138,14 +138,6 @@ export function activate(context: vscode.ExtensionContext) {
         context.subscriptions.push(dispose);
     }
 
-    add('extension.watchGhcidOutput', () => {
-        if (!vscode.window.activeTextEditor) {
-            vscode.window.showWarningMessage("You must open the Ghcid output first.");
-            return null;
-        }
-        let file = vscode.window.activeTextEditor.document.uri.fsPath;
-        return watchOutput(path.dirname(file), file);
-    });
     add('extension.startGhcid', () => {
         if (!vscode.workspace.rootPath) {
             vscode.window.showWarningMessage("You must open a workspace first.")

--- a/plugins/vscode/src/extension.ts
+++ b/plugins/vscode/src/extension.ts
@@ -150,10 +150,12 @@ export function activate(context: vscode.ExtensionContext) {
         context.subscriptions.push({dispose: () => {try {fs.unlinkSync(file);} catch (e) {};}});
         fs.writeFileSync(file, "");
 
+        let ghcidCommand : string = vscode.workspace.getConfiguration('ghcid').get('command');
+
         let opts : vscode.TerminalOptions =
             os.type().startsWith("Windows") ?
-                {shellPath: "cmd.exe", shellArgs: ["/k","ghcid"]} :
-                {shellPath: "ghcid", shellArgs: []};
+                {shellPath: "cmd.exe", shellArgs: ["/k", ghcidCommand]} :
+                {shellPath: ghcidCommand, shellArgs: []};
         opts.name = "ghcid";
         opts.shellArgs.push("--outputfile=" + file);
         oldTerminal = vscode.window.createTerminal(opts);


### PR DESCRIPTION
Since the vscode package is no longer requires the old watching output file thing,
the extra command now is just confusion prone.