### PR TITLE
Support a filetype 'ghcid' in the neovim plugin

### DIFF
--- a/plugins/nvim/doc/neovim-ghcid.txt
+++ b/plugins/nvim/doc/neovim-ghcid.txt
@@ -6,7 +6,8 @@ License: MIT
 
 USAGE                                                           *neovim-ghcid*
 
-Run this command to start Ghcid in a terminal buffer.
+Run this command to start Ghcid in a terminal buffer,
+This opens the buffer with filetype "ghcid".
 >
 	:Ghcid
 <

--- a/plugins/nvim/ftplugin/haskell.vim
+++ b/plugins/nvim/ftplugin/haskell.vim
@@ -122,7 +122,7 @@ function! s:ghcid_openwin()
 
   let s:ghcid_win_id = win_getid()
   call s:ghcid_update_status()
-  silent setlocal nobuflisted winfixheight
+  silent setlocal nobuflisted winfixheight filetype=ghcid
   normal! G
   echo
 endfunction


### PR DESCRIPTION
(I'm not English native, please tell the right sentence if the written sentence is unnatural :smiley:)

This allows to set the ftplugin by the user side that is like below .vim/after/ftplugin/ghcid.vim :dog2:

```vim
nnoremap <buffer><silent> <localleader>R :<C-u>terminal stack test<CR>
```

The above runs `stack test` :muscle: