### PR TITLE
Add hlint support

### DIFF
--- a/ghcid.cabal
+++ b/ghcid.cabal
@@ -60,7 +60,8 @@ executable ghcid
         process >= 1.1,
         cmdargs >= 0.10,
         ansi-terminal,
-        terminal-size >= 0.3
+        terminal-size >= 0.3,
+        hlint
     if os(windows)
         build-depends: Win32
     else

--- a/ghcid.cabal
+++ b/ghcid.cabal
@@ -60,8 +60,7 @@ executable ghcid
         process >= 1.1,
         cmdargs >= 0.10,
         ansi-terminal,
-        terminal-size >= 0.3,
-        hlint
+        terminal-size >= 0.3
     if os(windows)
         build-depends: Win32
     else

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -30,6 +30,7 @@ import Language.Haskell.Ghcid.Escape
 import Language.Haskell.Ghcid.Terminal
 import Language.Haskell.Ghcid.Util
 import Language.Haskell.Ghcid.Types
+import Language.Haskell.HLint3 (hlint)
 import Wait
 
 import Data.Functor
@@ -43,6 +44,7 @@ data Options = Options
     ,test :: [String]
     ,run :: [String]
     ,warnings :: Bool
+    ,lint :: Bool
     ,no_status :: Bool
     ,height :: Maybe Int
     ,width :: Maybe Int
@@ -75,6 +77,7 @@ options = cmdArgsMode $ Options
     ,test = [] &= name "T" &= typ "EXPR" &= help "Command to run after successful loading"
     ,run = [] &= name "r" &= typ "EXPR" &= opt "main" &= help "Command to run after successful loading (defaults to main)"
     ,warnings = False &= name "W" &= help "Allow tests to run even with warnings"
+    ,lint = False &= name "l" &= help "Show lint suggestions"
     ,no_status = False &= name "S" &= help "Suppress status messages"
     ,height = Nothing &= help "Number of lines to use (defaults to console height)"
     ,width = Nothing &= name "w" &= help "Number of columns to use (defaults to console width)"
@@ -281,8 +284,9 @@ runGhcid session waiter termSize termOutput opts@Options{..} = do
 
             let (countErrors, countWarnings) = both sum $ unzip
                     [if loadSeverity == Error then (1,0) else (0,1) | m@Message{..} <- messages, loadMessage /= []]
+            let failed = countErrors /= 0 || (countWarnings /= 0 && not warnings)
             test <- return $
-                if null test || countErrors /= 0 || (countWarnings /= 0 && not warnings) then Nothing
+                if null test || failed then Nothing
                 else Just $ intercalate "\n" test
 
             unless no_title $ setWindowIcon $
@@ -326,6 +330,9 @@ runGhcid session waiter termSize termOutput opts@Options{..} = do
                      else do
                         updateTitle "(test done)"
                         whenNormal $ outStrLn "\n...done"
+            when (lint && not failed) $ do
+                lints <- hlint loaded
+                forM_ lints (outStrLn . show)
 
             reason <- nextWait $ restart ++ reload ++ loaded
             whenLoud $ outStrLn $ "%RELOADING: " ++ unwords reason

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -22,7 +22,7 @@ import System.Directory.Extra
 import System.Time.Extra
 import System.Exit
 import System.FilePath
-import System.Process (readProcessWithExitCode)
+import System.Process
 import System.Info
 import System.IO.Extra
 
@@ -77,7 +77,7 @@ options = cmdArgsMode $ Options
     ,test = [] &= name "T" &= typ "EXPR" &= help "Command to run after successful loading"
     ,run = [] &= name "r" &= typ "EXPR" &= opt "main" &= help "Command to run after successful loading (defaults to main)"
     ,warnings = False &= name "W" &= help "Allow tests to run even with warnings"
-    ,lint = Nothing &= typ "LINTCMD" &= name "lint" &= opt "hlint" &= help "Run linter if there are no errors. Defaults to hlint."
+    ,lint = Nothing &= typ "COMMAND" &= name "lint" &= opt "hlint" &= help "Linter to run if there are no errors. Defaults to hlint."
     ,no_status = False &= name "S" &= help "Suppress status messages"
     ,height = Nothing &= help "Number of lines to use (defaults to console height)"
     ,width = Nothing &= name "w" &= help "Number of columns to use (defaults to console width)"
@@ -332,8 +332,8 @@ runGhcid session waiter termSize termOutput opts@Options{..} = do
                         whenNormal $ outStrLn "\n...done"
             whenJust lint $ \lintcmd ->
                 unless hasErrors $ do
-                    (exitcode, stdout, _) <- readProcessWithExitCode lintcmd loaded ""
-                    unless (exitcode == ExitSuccess) $ outStrLn stdout
+                    (exitcode, stdout, stderr) <- readProcessWithExitCode lintcmd loaded ""
+                    unless (exitcode == ExitSuccess) $ outStrLn (stdout ++ stderr)
 
             reason <- nextWait $ restart ++ reload ++ loaded
             whenLoud $ outStrLn $ "%RELOADING: " ++ unwords reason


### PR DESCRIPTION
Closes #158.
This is a little WIP proof of concept of hlint integration. It adds a `-l` flag that will run hlint if there are no errors, which covers my use cases. 
- [ ] On a 20K line project, this takes about 3s on my machine, is that reason to turn hlint into a persistent process?
- [ ] Do we want more command-line options than `-l`? I should add `.hlint.yaml` support at least.
- [ ] Are you happy with this approach @ndmitchell, or am I overlooking a more idiomatic way to do this?
