### PR TITLE
Ability to scroll through the error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,6 @@ Due to limitations in `ghci`, these flags are only set _after_ the first load. I
 
 #### I want to match on the file/line/column to get jump-to-error functionality in my editor.
 You will variously see `file:line:col:message`, `file:line:col1-col2:msg` and `file:(line1,col1)-(line2,col2):message`, as these are the formats GHC uses. To match all of them you can use a regular expression such as `^(\\S*?):(?|(\\d+):(\\d+)(?:-\\d+)?|\\((\\d+),(\\d+)\\)-\\(\\d+,\\d+\\)):([^\n]*)`.
+
+#### What if the error message is too big for my console?
+You can let `ghcid` print more with `--no-height-limit`. The first error message might end up outside of the console view, so you can use `--reverse-errors` to flip the order of the errors and warnings. Further error messages are just a scroll away. Finally if you're going to be scrolling, you can achieve a cleaner experience with the `--clear` flag, which clears the console on reload.

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -216,20 +216,18 @@ mainWithTerminal termSize termOutput =
                   then termSize { termHeight = Nothing }
                   else termSize
 
-                supportsANSI <- hSupportsANSI stdout
-
                 restyle <- do
-                    let useStyle = case color opts of
-                          Always -> True
-                          Never -> False
-                          Auto -> supportsANSI
+                    useStyle <- case color opts of
+                        Always -> return True
+                        Never -> return False
+                        Auto -> hSupportsANSI stdout
                     when useStyle $ do
                         h <- lookupEnv "HSPEC_OPTIONS"
                         when (isNothing h) $ setEnv "HSPEC_OPTIONS" "--color" -- see #87
                     return $ if useStyle then id else map unescape
 
                 clear <- return $
-                  if clear opts && supportsANSI
+                  if clear opts
                   then (clearScreen *>)
                   else id
 

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -173,7 +173,7 @@ withGhcidArgs act = do
 
 data TermSize = TermSize
     {termWidth :: Int
-    ,termHeight :: Maybe Int
+    ,termHeight :: Maybe Int -- ^ Nothing means the height is unlimited
     ,termWrap :: WordWrap
     }
 
@@ -210,9 +210,9 @@ mainWithTerminal termSize termOutput =
                             (if isJust w then WrapHard else termWrap term)
 
                 termSize <- return $
-                  if no_height_limit opts
-                  then termSize { termHeight = Nothing }
-                  else termSize
+                    if no_height_limit opts
+                    then termSize { termHeight = Nothing }
+                    else termSize
 
                 restyle <- do
                     useStyle <- case color opts of
@@ -225,9 +225,9 @@ mainWithTerminal termSize termOutput =
                     return $ if useStyle then id else map unescape
 
                 clear <- return $
-                  if clear opts
-                  then (clearScreen *>)
-                  else id
+                    if clear opts
+                    then (clearScreen *>)
+                    else id
 
                 maybe withWaiterNotify withWaiterPoll (poll opts) $ \waiter ->
                     runGhcid session waiter (return termSize) (clear . termOutput . restyle) opts
@@ -264,12 +264,12 @@ runGhcid session waiter termSize termOutput opts@Options{..} = do
             TermSize{..} <- termSize
             let wrap = concatMap (wordWrapE termWidth (termWidth `div` 5) . Esc)
             (msg, load, pad) <-
-              case termHeight of
-                Nothing -> return (wrap msg, wrap load, [])
-                Just termHeight -> do
-                  (termHeight, msg) <- return $ takeRemainder termHeight $ wrap msg
-                  (termHeight, load) <- return $ takeRemainder termHeight $ wrap load
-                  return (msg, load, replicate termHeight "")
+                case termHeight of
+                    Nothing -> return (wrap msg, wrap load, [])
+                    Just termHeight -> do
+                        (termHeight, msg) <- return $ takeRemainder termHeight $ wrap msg
+                        (termHeight, load) <- return $ takeRemainder termHeight $ wrap load
+                        return (msg, load, replicate termHeight "")
             let mergeSoft ((Esc x,WrapSoft):(Esc y,q):xs) = mergeSoft $ (Esc (x++y), q) : xs
                 mergeSoft ((x,_):xs) = x : mergeSoft xs
                 mergeSoft [] = []

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -47,7 +47,7 @@ data Options = Options
     ,lint :: Maybe String
     ,no_status :: Bool
     ,clear :: Bool
-    ,reversed :: Bool
+    ,reverse_errors :: Bool
     ,no_height_limit :: Bool
     ,height :: Maybe Int
     ,width :: Maybe Int
@@ -83,7 +83,7 @@ options = cmdArgsMode $ Options
     ,lint = Nothing &= typ "COMMAND" &= name "lint" &= opt "hlint" &= help "Linter to run if there are no errors. Defaults to hlint."
     ,no_status = False &= name "S" &= help "Suppress status messages"
     ,clear = False &= name "clear" &= help "Clear screen when reloading"
-    ,reversed = False &=name "reversed" &= help "Reverse output order"
+    ,reverse_errors = False &= help "Reverse output order (works best with --no-height-limit)"
     ,no_height_limit = False &= name "no-height-limit" &= help "Disable height limit"
     ,height = Nothing &= help "Number of lines to use (defaults to console height)"
     ,width = Nothing &= name "w" &= help "Number of columns to use (defaults to console width)"
@@ -328,7 +328,7 @@ runGhcid session waiter termSize termOutput opts@Options{..} = do
                 errTimes <- sequence [(x,) <$> getModTime x | x <- nubOrd $ map loadFile msgError]
                 let f x = lookup (loadFile x) errTimes
                     moduleSorted = sortOn (Down . f) msgError ++ msgWarn
-                return $ (if reversed then reverse else id) moduleSorted
+                return $ (if reverse_errors then reverse else id) moduleSorted
 
             outputFill currTime (Just (loadedCount, ordMessages)) ["Running test..." | isJust test]
             forM_ outputfile $ \file ->

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -141,9 +141,7 @@ autoOptions o@Options{..}
         stack <- firstJustM findStack [".",".."] -- stack file might be parent, see #62
 
         let cabal = map (curdir </>) $ filter ((==) ".cabal" . takeExtension) files
-        let opts = ["-fno-code" | null test && null run]
-                ++ ["-freverse-errors" | reversed ]
-                ++ ghciFlagsRequired ++ ghciFlagsUseful
+        let opts = ["-fno-code" | null test && null run] ++ ghciFlagsRequired ++ ghciFlagsUseful
         return $ case () of
             _ | Just stack <- stack ->
                 let flags = if null arguments then
@@ -329,10 +327,8 @@ runGhcid session waiter termSize termOutput opts@Options{..} = do
                 -- sort error messages by modtime, so newer edits cause the errors to float to the top - see #153
                 errTimes <- sequence [(x,) <$> getModTime x | x <- nubOrd $ map loadFile msgError]
                 let f x = lookup (loadFile x) errTimes
-                return $
-                  if reversed
-                  then msgWarn ++ sortOn f msgError
-                  else sortOn (Down . f) msgError ++ msgWarn
+                    moduleSorted = sortOn (Down . f) msgError ++ msgWarn
+                return $ (if reversed then reverse else id) moduleSorted
 
             outputFill currTime (Just (loadedCount, ordMessages)) ["Running test..." | isJust test]
             forM_ outputfile $ \file ->

--- a/src/Test/Ghcid.hs
+++ b/src/Test/Ghcid.hs
@@ -77,7 +77,7 @@ withGhcid args script = do
     res <- bracket
         (flip forkFinally (const $ signalBarrier done ()) $
             withArgs (["--no-title","--no-status"]++args) $
-                mainWithTerminal (return $ TermSize 100 50 WrapHard) output)
+                mainWithTerminal (return $ TermSize 100 (Just 50) WrapHard) output)
         killThread $ \_ -> script require
     waitBarrier done
     return res


### PR DESCRIPTION
**Motivation**:
At work we often have to deal with big error messages. We love `ghcid` and use it all the time, but when we get to the big error messages, we end up having to kill `ghcid` and run `cabal new-repl` or any other appropriate command in order to see the full error message and not just the cropped version. This is a much slower iteration loop.

I have searched through the `ghcid` options and the GitHub issues and couldn't find anything that could help with this.

**Solution**:
I understand `ghcid`'s tag line of being a *low feature* IDE. As such I don't add actual scrolling to `ghcid` but rather add a small set of options that make it possible to use the terminal itself or `tmux` to do the scrolling.

A way to output all the errors and warning while still keeping the most relevant ones visible in a terminal is simply to reverse their order.
GHC already offers a flag to do just that: `-freverse-errors` (it works for warnings too).

This PR focuses on adding the following features as 3 separate flags:

- `no-height-limit`: This is the core of the PR, in order to see all the errors we need to disable the height limiting code.
- `reversed`: Uses GHC's `-freverse-errors`. When using the `-c` flag, it's up to the user to call GHC's `-freverse-errors` (either in a `.cabal` file or explicitly in the command). `ghcid` already had some custom logic for ordering errors and warning, this flags changes that custom logic to work properly in reversed order.
- `clear`: When scrolling up we want to see clear divisions between reloads, clearing the screen in between reloads is a nice way to achieve that.

These 3 flags mostly make sense together, so if you would prefer these options were all behind a single flag, I can do that! :smile: 