### PR TITLE
Add vim-ghcid-quickfix to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ There are a few plugins that integrate Ghcid into editors, notably:
 
 * [VS Code](plugins/vscode/)
 * [nvim](plugins/nvim/)
+* [vim](https://github.com/aiya000/vim-ghcid-quickfix)
 * [Emacs](plugins/emacs/)
 
 ### Usage tips


### PR DESCRIPTION
I created a vim-plugin to open ghcid on Vim :smiley:

Please introduce it to allow to use ghcid for Vim users :D

Of cource, I don't want to coerce it!
Please close this PR if you don't agree this :+1:

Thanks!
