### PR TITLE
ghcid: link with -rtsopts to be able to use RTS

### DIFF
--- a/ghcid.cabal
+++ b/ghcid.cabal
@@ -47,7 +47,7 @@ library
 executable ghcid
     hs-source-dirs: src
     default-language: Haskell2010
-    ghc-options: -main-is Ghcid.main -threaded
+    ghc-options: -main-is Ghcid.main -threaded -rtsopts
     main-is: Ghcid.hs
     build-depends:
         base >= 4.7 && < 5,


### PR DESCRIPTION
On our project, ghcid eats up 30G of memory
and freezes my laptop, so I'd like to limit that using 
RTSOPTS="-M4M" but ghcid is not compiled with
rtsopts support yet.