### PR TITLE
Implement "Rethinking REPLs"

### DIFF
--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -100,7 +100,7 @@ options = cmdArgsMode $ Options
     ,max_messages = Nothing &= name "n" &= help "Maximum number of messages to print"
     ,color = Auto &= name "colour" &= name "color" &= opt Always &= typ "always/never/auto" &= help "Color output (defaults to when the terminal supports it)"
     ,setup = [] &= name "setup" &= typ "COMMAND" &= help "Setup commands to pass to ghci on stdin, usually :set <something>"
-    ,allow_eval = False &= name "allow-eval" &= help "Allow execution of arbitrary REPL commands in comments"
+    ,allow_eval = False &= name "allow-eval" &= help "Execute REPL commands in comments"
     } &= verbosity &=
     program "ghcid" &= summary ("Auto reloading GHCi daemon v" ++ showVersion version)
 
@@ -398,14 +398,14 @@ prettyOutput _ _ xs evals = concatMap loadMessage xs ++ concatMap printEval eval
 printEval :: ((FilePath, (Int, Int)), (String, String)) -> [String]
 printEval ((file, (line, col)), (msg, result)) = do
   [ " "
-    , mconcat
+    , concat
         [ file
         , ":"
         , show line
         , ":"
         , show col
         ]
-    ] ++ (zipWith (++) (repeat "λ> ") $ lines msg)
+    ] ++ (map ("$> " ++) $ lines msg)
       ++ lines result
 
 

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -391,12 +391,12 @@ runGhcid session waiter termSize termOutput opts@Options{..} = do
 -- | Given an available height, and a set of messages to display, show them as best you can.
 prettyOutput :: String -> Int -> [Load] -> [((FilePath, (Int, Int)), (String, String))] -> [String]
 prettyOutput currTime loadedCount [] evals =
-    [allGoodMessage ++ " (" ++ show loadedCount ++ " module" ++ ['s' | loadedCount /= 1] ++ ", at " ++ currTime ++ ")"
-    ] ++ concatMap printEval evals
+    (allGoodMessage ++ " (" ++ show loadedCount ++ " module" ++ ['s' | loadedCount /= 1] ++ ", at " ++ currTime ++ ")")
+        : concatMap printEval evals
 prettyOutput _ _ xs evals = concatMap loadMessage xs ++ concatMap printEval evals
 
 printEval :: ((FilePath, (Int, Int)), (String, String)) -> [String]
-printEval ((file, (line, col)), (msg, result)) = do
+printEval ((file, (line, col)), (msg, result)) =
   [ " "
     , concat
         [ file
@@ -405,7 +405,7 @@ printEval ((file, (line, col)), (msg, result)) = do
         , ":"
         , show col
         ]
-    ] ++ (map ("$> " ++) $ lines msg)
+    ] ++ map ("$> " ++) (lines msg)
       ++ lines result
 
 

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -63,6 +63,7 @@ data Options = Options
     ,max_messages :: Maybe Int
     ,color :: ColorMode
     ,setup :: [String]
+    ,allow_eval :: Bool
     }
     deriving (Data,Typeable,Show)
 
@@ -99,6 +100,7 @@ options = cmdArgsMode $ Options
     ,max_messages = Nothing &= name "n" &= help "Maximum number of messages to print"
     ,color = Auto &= name "colour" &= name "color" &= opt Always &= typ "always/never/auto" &= help "Color output (defaults to when the terminal supports it)"
     ,setup = [] &= name "setup" &= typ "COMMAND" &= help "Setup commands to pass to ghci on stdin, usually :set <something>"
+    ,allow_eval = False &= name "allow-eval" &= help "Allow execution of arbitrary REPL commands in comments"
     } &= verbosity &=
     program "ghcid" &= summary ("Auto reloading GHCi daemon v" ++ showVersion version)
 
@@ -230,7 +232,7 @@ mainWithTerminal termSize termOutput =
                     else id
 
                 maybe withWaiterNotify withWaiterPoll (poll opts) $ \waiter ->
-                    runGhcid session waiter (return termSize) (clear . termOutput . restyle) opts
+                    runGhcid session{allowEval = allow_eval opts} waiter (return termSize) (clear . termOutput . restyle) opts
 
 
 

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -232,7 +232,7 @@ mainWithTerminal termSize termOutput =
                     else id
 
                 maybe withWaiterNotify withWaiterPoll (poll opts) $ \waiter ->
-                    runGhcid session{allowEval = allow_eval opts} waiter (return termSize) (clear . termOutput . restyle) opts
+                    runGhcid (if allow_eval opts then enableEval session else session) waiter (return termSize) (clear . termOutput . restyle) opts
 
 
 

--- a/src/Language/Haskell/Ghcid/Types.hs
+++ b/src/Language/Haskell/Ghcid/Types.hs
@@ -45,7 +45,7 @@ data Load
       LoadConfig
         {loadFile :: FilePath -- ^ The file that was being loaded, @.ghci@.
         }
-    | -- | A config file was loaded, usually a .ghci file (GHC 8.2 and above only)
+    | -- | A response to an eval comment
       EvalResult
         {loadFile :: FilePath -- ^ The file that was being loaded, @.ghci@.
         ,loadFilePos :: (Int, Int)

--- a/src/Language/Haskell/Ghcid/Types.hs
+++ b/src/Language/Haskell/Ghcid/Types.hs
@@ -45,6 +45,13 @@ data Load
       LoadConfig
         {loadFile :: FilePath -- ^ The file that was being loaded, @.ghci@.
         }
+    | -- | A config file was loaded, usually a .ghci file (GHC 8.2 and above only)
+      EvalResult
+        {loadFile :: FilePath -- ^ The file that was being loaded, @.ghci@.
+        ,loadFilePos :: (Int, Int)
+        ,evalCommand :: String
+        ,evalResult :: String
+        }
     deriving (Show, Eq, Ord)
 
 -- | Is a 'Load' a 'Message'?

--- a/src/Language/Haskell/Ghcid/Types.hs
+++ b/src/Language/Haskell/Ghcid/Types.hs
@@ -4,7 +4,7 @@
 module Language.Haskell.Ghcid.Types(
     GhciError(..),
     Stream(..),
-    Load(..), Severity(..),
+    Load(..), Severity(..), EvalResult(..),
     isMessage, isLoading, isLoadConfig
     ) where
 
@@ -46,12 +46,15 @@ data Load
         {loadFile :: FilePath -- ^ The file that was being loaded, @.ghci@.
         }
     | -- | A response to an eval comment
-      EvalResult
-        {loadFile :: FilePath -- ^ The file that was being loaded, @.ghci@.
-        ,loadFilePos :: (Int, Int)
-        ,evalCommand :: String
-        ,evalResult :: String
-        }
+      Eval EvalResult
+    deriving (Show, Eq, Ord)
+
+data EvalResult = EvalResult
+    {evalFile :: FilePath -- ^ The file that was being loaded, @.ghci@.
+    ,evalFilePos :: (Int, Int)
+    ,evalCommand :: String
+    ,evalResult :: String
+    }
     deriving (Show, Eq, Ord)
 
 -- | Is a 'Load' a 'Message'?

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -141,7 +141,7 @@ performEvals ghci True reloaded = do
     fmap join $ forM cmds $ \(file, cmds') ->
         forM cmds' $ \(num, cmd) -> do
             ref <- newIORef []
-            execStream ghci (intercalate " " $ lines cmd) $ \_ resp -> modifyIORef ref (++ resp)
+            execStream ghci (unwords $ lines cmd) $ \_ resp -> modifyIORef ref (++ resp)
             resp <- readIORef ref
             return $ EvalResult file (num, 1) cmd resp
 

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -3,7 +3,7 @@
 -- | A persistent version of the Ghci session, encoding lots of semantics on top.
 --   Not suitable for calling multithreaded.
 module Session(
-    Session(allowEval), withSession,
+    Session, enableEval, withSession,
     sessionStart, sessionReload,
     sessionExecAsync,
     ) where
@@ -39,6 +39,9 @@ data Session = Session
     ,withThread :: ThreadId -- ^ Thread that called withSession
     ,allowEval :: Bool  -- ^ Is the allow-eval flag set?
     }
+
+enableEval :: Session -> Session
+enableEval s = s { allowEval = True }
 
 
 debugShutdown x = when False $ print ("DEBUG SHUTDOWN", x)

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -27,6 +27,7 @@ import Prelude
 import Data.Foldable
 import Data.Char
 import Data.Function
+import System.IO.Extra
 
 
 data Session = Session
@@ -148,7 +149,7 @@ performEvals ghci True reloaded = do
 
 getCommands :: FilePath -> IO (FilePath, [(Int, String)])
 getCommands fp = do
-    ls <- readFile fp
+    ls <- readFileUTF8' fp
     return (fp, splitCommands $ zipFrom 1 $ lines ls)
 
 splitCommands :: [(Int, String)] -> [(Int, String)]

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -147,7 +147,7 @@ performEvals ghci True reloaded = do
             ref <- newIORef []
             execStream ghci (unwords $ lines cmd) $ \_ resp -> modifyIORef ref (resp :)
             resp <- concat . reverse <$> readIORef ref
-            return $ EvalResult file (num, 1) cmd resp
+            return $ Eval $ EvalResult file (num, 1) cmd resp
 
 
 getCommands :: FilePath -> IO (FilePath, [(Int, String)])

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -142,8 +142,8 @@ performEvals ghci True reloaded = do
     fmap join $ forM cmds $ \(file, cmds') ->
         forM cmds' $ \(num, cmd) -> do
             ref <- newIORef []
-            execStream ghci (unwords $ lines cmd) $ \_ resp -> modifyIORef ref (++ resp)
-            resp <- readIORef ref
+            execStream ghci (unwords $ lines cmd) $ \_ resp -> modifyIORef ref (resp :)
+            resp <- concat . reverse <$> readIORef ref
             return $ EvalResult file (num, 1) cmd resp
 
 

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -167,7 +167,7 @@ isCommand :: String -> Bool
 isCommand = isPrefixOf commandPrefix
 
 commandPrefix :: String
-commandPrefix = "-- > "
+commandPrefix = "-- $> "
 
 
 

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -24,9 +24,6 @@ import Data.Maybe
 import Data.List.Extra
 import Control.Applicative
 import Prelude
-import Data.Foldable
-import Data.Char
-import Data.Function
 import System.IO.Extra
 
 


### PR DESCRIPTION
This PR implements the [Unison notebook](http://unisonweb.org/2018-09-25/repl.html#rethinking-repls-and-notebooks) idea --- essentially adding support for interactive REPL commands directly in source code.

The idea is that I can write the following:

```haskell
magic :: String -> String
magic = reverse

-- $> magic "hello world"
```

to which, ghcid will now reply:

```
All good (25 modules, at 17:42:54)

/home/sandy/prj/polysemy/src/Polysemy.hs:160:1
$> magic "hello world"
"dlrow olleh"
```

In essence, this lets you run little repl commands directly in your source file.

Link to the original idea in Unison: https://github.com/unisonweb/unison/pull/252