### PR TITLE
Fix ctrl-c keeping the cursor hidden after a test

### DIFF
--- a/src/Session.hs
+++ b/src/Session.hs
@@ -79,6 +79,7 @@ kill ghci = ignored $ do
     debugShutdown "After terminateProcess"
     -- Ctrl-C after a tests keeps the cursor hidden,
     -- `setSGR []`didn't seem to be enough
+    -- See: https://github.com/ndmitchell/ghcid/issues/254
     showCursor
 
 loadedModules :: [Load] -> [FilePath]

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -14,6 +14,7 @@ import Language.Haskell.Ghcid.Escape
 import Language.Haskell.Ghcid.Util
 import Language.Haskell.Ghcid.Types
 import Data.IORef
+import System.Console.ANSI
 import System.Time.Extra
 import System.Process
 import System.FilePath
@@ -76,7 +77,9 @@ kill ghci = ignored $ do
     debugShutdown "Before terminateProcess"
     ignored $ terminateProcess $ process ghci
     debugShutdown "After terminateProcess"
-
+    -- Ctrl-C after a tests keeps the cursor hidden,
+    -- `setSGR []`didn't seem to be enough
+    showCursor
 
 loadedModules :: [Load] -> [FilePath]
 loadedModules = nubOrd . map loadFile . filter (not . isLoadConfig)


### PR DESCRIPTION
Closes https://github.com/ndmitchell/ghcid/issues/254

Whenever I `ctrl-c` out of `ghcid` while it's running a test (or after), I lose the cursor in my terminal. I can then fix my terminal with either:

```sh
reset
```

or:

```sh
stty sane
tput rs1
```

as I found out [here](https://unix.stackexchange.com/questions/79684/fix-terminal-after-displaying-a-binary-file).
However I would rather ghcid didn't leave me without my cursor.

The tests I am running use `hspec` if that matters, but I think regardless of what my tests print to `stdout`, `ghcid` should clean up after killing the subprocess.

Note: I am not sure if I need to check if `ghcid` is running in a TTY that supports ANSI controls. If you think that's necessary, I can add some checks. :smile: