### PR TITLE
Interpret `lint` as a shell command instead of an executable

### DIFF
--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -161,9 +161,9 @@ autoOptions o@Options{..}
     where
         f c r = o{command = unwords $ c ++ map escape arguments, arguments = [], restart = restart ++ r, run = [], test = run ++ test}
 
-        -- in practice we're not expecting many arguments to have anything funky in them
-        escape x | ' ' `elem` x = "\"" ++ x ++ "\""
-                 | otherwise = x
+-- | Simple escaping for command line arguments. Wraps a string in double quotes if it contains a space.
+escape x | ' ' `elem` x = "\"" ++ x ++ "\""
+         | otherwise = x
 
 -- | Use arguments from .ghcid if present
 withGhcidArgs :: IO a -> IO a
@@ -366,7 +366,7 @@ runGhcid session waiter termSize termOutput opts@Options{..} = do
                         whenNormal $ outStrLn "\n...done"
             whenJust lint $ \lintcmd ->
                 unless hasErrors $ do
-                    (exitcode, stdout, stderr) <- readCreateProcessWithExitCode (shell . unwords $ lintcmd : loaded) ""
+                    (exitcode, stdout, stderr) <- readCreateProcessWithExitCode (shell . unwords $ lintcmd : map escape loaded) ""
                     unless (exitcode == ExitSuccess) $ outStrLn (stdout ++ stderr)
 
             reason <- nextWait $ restart ++ reload ++ loaded

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -366,7 +366,7 @@ runGhcid session waiter termSize termOutput opts@Options{..} = do
                         whenNormal $ outStrLn "\n...done"
             whenJust lint $ \lintcmd ->
                 unless hasErrors $ do
-                    (exitcode, stdout, stderr) <- readProcessWithExitCode lintcmd loaded ""
+                    (exitcode, stdout, stderr) <- readCreateProcessWithExitCode (shell . unwords $ lintcmd : loaded) ""
                     unless (exitcode == ExitSuccess) $ outStrLn (stdout ++ stderr)
 
             reason <- nextWait $ restart ++ reload ++ loaded


### PR DESCRIPTION
Lint commands cannot take arguments since it's the argument to `readProcess`, and therefore needs to exactly name an executable. For instance, `ghcid --lint="hlint --color"` crashes, and this fixes that.
That said, I'm not entirely sure if there are any nuances that I might be overlooking that make this a bad idea?