### PR TITLE
Improvements for emacs

### DIFF
--- a/plugins/emacs/ghcid.el
+++ b/plugins/emacs/ghcid.el
@@ -1,74 +1,133 @@
 ;; Really basic ghcid+stack support in emacs with compilation-mode
 ;; Use M-x ghcid to launch
 
+(require 'term)
+
 ;; Set ghcid-target to change the stack target
 (setq ghcid-target "")
 
-(setq ghcid-height 15)
-(defun ghcid-stack-cmd (target)
-      (format "stack ghci %s --test --bench --ghci-options=-fno-code" target))
+(setq ghcid-process-name "ghcid")
 
-(setq ghcid-buf-name "*ghcid*")
 
 (define-minor-mode ghcid-mode
-  "A minor mode for ghcid terminals"
+  "A minor mode for ghcid terminals
+
+Use `ghcid' to start a ghcid session in a new buffer. The process
+will start in the directory of your current buffer.
+
+It is based on `compilation-mode'. That means the errors and
+warnings can be clicked and the `next-error'(\\[next-error]) and
+`previous-error'(\\[previous-error]) commands will work as usual.
+
+To configure where the new buffer should appear, customize your
+`display-buffer-alist'. For instance like so:
+
+    (add-to-list
+     \\='display-buffer-alist
+     \\='(\"*ghcid*\"
+       (display-buffer-reuse-window   ;; First try to reuse an existing window
+        display-buffer-at-bottom      ;; Then try a new window at the bottom
+        display-buffer-pop-up-window) ;; Otherwise show a pop-up
+       (window-height . 18)      ;; New window will be 18 lines
+       ))
+
+If the window that shows ghcid changes size, the process will not
+recognize the new height until you manually restart it by calling
+`ghcid' again.
+"
   :lighter " Ghcid"
-  (nlinum-mode -1)
+  (when (fboundp 'nlinum-mode) (nlinum-mode -1))
   (linum-mode -1)
   (compilation-minor-mode))
 
-(defun new-ghcid-term ()
-  (interactive)
-  (kill-ghcid)
-  (let ((ghcid-buf (get-buffer-create ghcid-buf-name)))
-    (display-buffer
-     ghcid-buf
-     '((display-buffer-at-bottom
-        display-buffer-pop-up-window
-        display-buffer-reuse-window)
-       (window-height . 18)))
-    (select-window (get-buffer-window ghcid-buf))
-    (make-term "ghcid" "/bin/bash")
-    (term-mode)
-    (term-char-mode)
-    (term-set-escape-char ?\C-x)
-    (setq-local term-buffer-maximum-size ghcid-height)
-    (setq-local scroll-up-aggressively 1)
-    (ghcid-mode)))
 
-(defun kill-ghcid ()
-  (let* ((ghcid-buf (get-buffer ghcid-buf-name))
-         (ghcid-proc (get-buffer-process ghcid-buf)))
-    (when (processp ghcid-proc)
-      (progn
-        (set-process-query-on-exit-flag ghcid-proc nil)
-        (kill-process ghcid-proc)))))
+;; Compilation mode does some caching for markers in files, but it gets confused
+;; because ghcid reloads the files in the same process. Here we parse the
+;; 'Reloading...' message from ghcid and flush the cache for the mentioned
+;; files. This approach is very similar to the 'omake' hacks included in
+;; compilation mode.
+(add-to-list
+  'compilation-error-regexp-alist-alist
+  '(ghcid-reloading
+    "Reloading\\.\\.\\.\\(\\(\n  .+\\)*\\)" 1 nil nil nil nil
+    (0 (progn
+         (let* ((filenames (cdr (split-string (match-string 1) "\n  "))))
+           (dolist (filename filenames)
+             (compilation--flush-file-structure filename)))
+         nil))
+    ))
+(add-to-list 'compilation-error-regexp-alist 'ghcid-reloading)
 
-(defun add-stars (s) (format "*%s*" s))
+
+(defun ghcid-buffer-name ()
+  (concat "*" ghcid-process-name "*"))
+
+(defun ghcid-stack-cmd (target)
+  (format "stack ghci %s --test --bench --ghci-options=-fno-code" target))
 
 ;; TODO Pass in compilation command like compilation-mode
 (defun ghcid-command (h)
     (format "ghcid -c \"%s\" -h %s\n" (ghcid-stack-cmd ghcid-target) h))
 
+(defun ghcid-get-buffer ()
+  "Create or reuse a ghcid buffer with the configured name and
+display it. Return the window that shows the buffer.
+
+User configuration will influence where the buffer gets shown
+exactly. See `ghcid-mode'."
+  (display-buffer (get-buffer-create (ghcid-buffer-name)) '((display-buffer-reuse-window))))
+
+(defun ghcid-start (dir)
+  "Start ghcid in the specified directory"
+
+  (with-selected-window (ghcid-get-buffer)
+
+    (setq next-error-last-buffer (current-buffer))
+    (setq-local default-directory dir)
+
+    ;; Only now we can figure out the height to pass along to the ghcid process
+    (let ((height (- (window-body-size) 1)))
+
+      (term-mode)
+      (term-line-mode)  ;; Allows easy navigation through the buffer
+      (ghcid-mode)
+
+      (setq-local term-buffer-maximum-size height)
+      (setq-local scroll-up-aggressively 1)
+      (setq-local show-trailing-whitespace nil)
+
+      (term-exec (ghcid-buffer-name)
+           ghcid-process-name
+           "/bin/bash"
+           nil
+           (list "-c" (ghcid-command height)))
+
+      )))
+
+(defun ghcid-kill ()
+  (let* ((ghcid-buf (get-buffer (ghcid-buffer-name)))
+         (ghcid-proc (get-buffer-process ghcid-buf)))
+    (when (processp ghcid-proc)
+      (progn
+        (set-process-query-on-exit-flag ghcid-proc nil)
+        (kill-process ghcid-proc)
+        ))))
+
 ;; TODO Close stuff if it fails
 (defun ghcid ()
-  "Run ghcid"
+  "Start a ghcid process in a new window. Kills any existing sessions.
+
+The process will be started in the directory of the buffer where
+you ran this command from."
   (interactive)
-  (let ((cur (selected-window)))
-    (new-ghcid-term)
-    (comint-send-string ghcid-buf-name (ghcid-command ghcid-height))
-    (select-window cur)))
+  (ghcid-start default-directory))
 
 ;; Assumes that only one window is open
 (defun ghcid-stop ()
   "Stop ghcid"
   (interactive)
-  (let* ((ghcid-buf (get-buffer ghcid-buf-name))
-         (ghcid-window (get-buffer-window ghcid-buf)))
-    (when ghcid-buf
-      (progn
-        (kill-ghcid)
-        (select-window ghcid-window)
-        (kill-buffer-and-window)))))
+  (ghcid-kill)
+  (kill-buffer (ghcid-buffer-name)))
+
 
 (provide 'ghcid)


### PR DESCRIPTION
I found the emacs mode quite buggy. These are the changes I've been using locally for a while now.

The window creation behaviour has changed, you can recover the old behaviour by putting the
following in your init.el:

    (add-to-list
     'display-buffer-alist
     '(\"*ghcid*\"
       (display-buffer-reuse-window   ;; First try to reuse an existing window
        display-buffer-at-bottom      ;; Then try a new window at the bottom
        display-buffer-pop-up-window) ;; Otherwise show a pop-up
       (window-height . 18)      ;; New window will be 18 lines
       ))

Improvements:

* Don't assume that nlinum-mode is available.
* Respect user configuration when displaying the buffer. Now it works with purpose-mode and custom
  `display-buffer-alist`s
* Automatically detect height of ghcid window.
* Use the standard `with-selected-window` to temporarily select the ghcid window.
* Use term-line-mode instead of term-char-mode, so the usual navigation shortcuts work in the ghcid
  buffer.
* Resets the directory of the ghcid process if you call `ghcid` again.
* Fix bug where the `next-error` would not always go the the right place in a file.

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
