### PR TITLE
Fix CHANGES reference to the new allow-eval flag

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,7 +8,7 @@ Changelog for ghcid (* = breaking change)
     #263, fix not resizing on terminal resize
     #262, add --test-message flag
     #253, try and keep the cursor visible after Ctrl-C
-    #248, add --eval flag to evaluate code snippets
+    #248, add --allow-eval flag to evaluate code snippets
     #245, link with -rtsopts to be able to use RTS flags
 0.7.4, released 2019-04-17
     #237, ability to cope better with large error messages


### PR DESCRIPTION
Hi, thanks for all the work on ghcid, It became essential tool in my workflow :-)
I just read this [blogpost](https://jkeuhlen.com/2019/10/19/Compile-Your-Comments-In-Ghcid.html) about the recently added `--allow-eval` flag. This just corrects changelog reference to it as it tripped me up a bit. 