### PR TITLE
Suggestion to fix dangling ghc process on double ctrl+c

### DIFF
--- a/ghcid.cabal
+++ b/ghcid.cabal
@@ -34,6 +34,10 @@ library
         process >= 1.1,
         ansi-terminal,
         cmdargs >= 0.10
+    if os(windows)
+        build-depends: Win32
+    else
+        build-depends: unix
 
     exposed-modules:
         Language.Haskell.Ghcid

--- a/src/Language/Haskell/Ghcid.hs
+++ b/src/Language/Haskell/Ghcid.hs
@@ -21,6 +21,7 @@ import Data.Maybe
 import Data.IORef
 import Control.Applicative
 import Data.Unique
+import System.Posix.Signals (installHandler, Handler(Catch), sigINT, sigTERM)
 
 import System.Console.CmdArgs.Verbosity
 
@@ -191,6 +192,9 @@ startGhciProcess process echo0 = do
         -- so try a showModules to capture the information again
         r2 <- if any isLoading r1 then return [] else map (uncurry Loading) <$> showModules ghci
         execStream ghci "" echo0
+
+        installHandler sigINT (Catch $ quit ghci) Nothing
+
         return (ghci, r1 ++ r2)
 
 


### PR DESCRIPTION
Hi!

This PR is not meant to be merged. Instead, I'd like to open the discussion to find possible solutions to #257

Debugging the code, not fully looking at it, I noticed that when you press ctrl+c once it seems `quit` will be called, which in turn will call `interrupt` and then `ghciInterrupt`. However, if you press ctrl+c once again the process will shutdown immediately and a dangling `ghc` might happen.

Just to try things to improve this, I used `installHandler` to trap SIGINT (ctrl+c). When I did that, every time you press ctrl+c, no matter how many times, the handler call will run. So I tried putting `quit` there and it works fine. However, the second time it will print some failure (because we already called `terminateProcess`) but it at least doesn't leave a dangling `ghc`, so it's already slightly better than the current situation. Ideally the second `ctrl+c` would do nothing: just wait for the process to exit, or maybe just ignore the second `ctrl+c`, I don't know.

Thoughts?

The dangling `ghc` is not a blocker but I'd definitely like to prevent it.