### PR TITLE
Handle GHCI unexpected errors better

### DIFF
--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -181,10 +181,20 @@ data TermSize = TermSize
     ,termWrap :: WordWrap
     }
 
+-- | Modify IO to catch runtime exceptions.
+handleErrors :: IO () -> IO ()
+handleErrors = handle $ \err -> case err of
+    UnexpectedExit cmd _ mmsg -> do
+        putStr $ "Command \"" ++ cmd ++ "\" exited unexpectedly"
+        case mmsg of
+            Just msg -> putStrLn $ " with error message: " <> msg
+            Nothing -> putStrLn ""
+        exitFailure
+
 -- | Like 'main', but run with a fake terminal for testing
 mainWithTerminal :: IO TermSize -> ([String] -> IO ()) -> IO ()
 mainWithTerminal termSize termOutput =
-    handle (\(UnexpectedExit cmd _) -> do putStrLn $ "Command \"" ++ cmd ++ "\" exited unexpectedly"; exitFailure) $
+    handleErrors $
         forever $ withWindowIcon $ withSession $ \session -> do
             setVerbosity Normal -- undo any --verbose flags
 

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -181,15 +181,14 @@ data TermSize = TermSize
     ,termWrap :: WordWrap
     }
 
--- | Modify IO to catch runtime exceptions.
+-- | On the 'UnexpectedExit' exception exit with a nice error message.
 handleErrors :: IO () -> IO ()
-handleErrors = handle $ \err -> case err of
-    UnexpectedExit cmd _ mmsg -> do
-        putStr $ "Command \"" ++ cmd ++ "\" exited unexpectedly"
-        case mmsg of
-            Just msg -> putStrLn $ " with error message: " <> msg
-            Nothing -> putStrLn ""
-        exitFailure
+handleErrors = handle $ \(UnexpectedExit cmd _ mmsg) -> do
+    putStr $ "Command \"" ++ cmd ++ "\" exited unexpectedly"
+    putStrLn $ case mmsg of
+        Just msg -> " with error message: " <> msg
+        Nothing -> ""
+    exitFailure
 
 -- | Like 'main', but run with a fake terminal for testing
 mainWithTerminal :: IO TermSize -> ([String] -> IO ()) -> IO ()

--- a/src/Language/Haskell/Ghcid.hs
+++ b/src/Language/Haskell/Ghcid.hs
@@ -96,19 +96,20 @@ startGhciProcess process echo0 = do
                 syncReplay
 
         -- Consume from a stream until EOF (return Nothing) or some predicate returns Just
-        let consume :: Stream -> (String -> IO (Maybe a)) -> IO (Maybe a)
+        let consume :: Stream -> (String -> IO (Maybe a)) -> IO (Either (Maybe String) a)
             consume name finish = do
                 let h = if name == Stdout then out else err
-                fix $ \rec -> do
+                flip fix Nothing $ \rec oldMsg -> do
                     el <- tryBool isEOFError $ hGetLine h
                     case el of
-                        Left _ -> return Nothing
+                        Left _ -> return $ Left oldMsg
                         Right l -> do
                             whenLoud $ outStrLn $ "%" ++ upper (show name) ++ ": " ++ l
-                            res <- finish $ removePrefix l
+                            let msg = removePrefix l
+                            res <- finish msg
                             case res of
-                                Nothing -> rec
-                                Just a -> return $ Just a
+                                Nothing -> rec $ Just msg
+                                Just a -> return $ Right a
 
         let consume2 :: String -> (Stream -> String -> IO (Maybe a)) -> IO (a,a)
             consume2 msg finish = do
@@ -118,11 +119,14 @@ startGhciProcess process echo0 = do
                 res2 <- onceFork $ consume Stderr (finish Stderr)
                 res1 <- res1
                 res2 <- res2
-                case liftM2 (,) res1 res2 of
-                    Nothing -> case cmdspec process of
-                        ShellCommand cmd -> throwIO $ UnexpectedExit cmd msg
-                        RawCommand exe args -> throwIO $ UnexpectedExit (unwords (exe:args)) msg
-                    Just v -> return v
+                case (res1, res2) of
+                    (Right v1, Right v2) -> return (v1, v2)
+                    (_, Left err) -> case cmdspec process of
+                        ShellCommand cmd -> throwIO $ UnexpectedExit cmd msg err
+                        RawCommand exe args -> throwIO $ UnexpectedExit (unwords (exe:args)) msg err
+                    (_, Right _) -> case cmdspec process of
+                        ShellCommand cmd -> throwIO $ UnexpectedExit cmd msg Nothing
+                        RawCommand exe args -> throwIO $ UnexpectedExit (unwords (exe:args)) msg Nothing
 
         -- held while interrupting, and briefly held when starting an exec
         -- ensures exec values queue up behind an ongoing interrupt and no two interrupts run at once

--- a/src/Language/Haskell/Ghcid/Types.hs
+++ b/src/Language/Haskell/Ghcid/Types.hs
@@ -12,8 +12,11 @@ import Data.Data
 import Control.Exception.Base (Exception)
 
 -- | GHCi shut down
-data GhciError = UnexpectedExit String String (Maybe String)
-    deriving (Show,Eq,Ord,Typeable,Data)
+data GhciError = UnexpectedExit {
+    _ghciErrorCmd :: String
+  , _ghciErrorMsg :: String
+  , _ghciErrorLastStdErr :: Maybe String
+  } deriving (Show, Eq, Ord, Typeable, Data)
 
 -- | Make GhciError an exception
 instance Exception GhciError

--- a/src/Language/Haskell/Ghcid/Types.hs
+++ b/src/Language/Haskell/Ghcid/Types.hs
@@ -12,7 +12,7 @@ import Data.Data
 import Control.Exception.Base (Exception)
 
 -- | GHCi shut down
-data GhciError = UnexpectedExit String String
+data GhciError = UnexpectedExit String String (Maybe String)
     deriving (Show,Eq,Ord,Typeable,Data)
 
 -- | Make GhciError an exception


### PR DESCRIPTION
First reported in
https://github.com/obsidiansystems/obelisk/issues/563, we see an issue
where ghci crashes had bad error messages in ghcid. Only information
given was "unexpected error" and the command that was run.

To better handle this, we need to modify the “consume” functions to
better keep track of error messages. This changes the type signature
from a Maybe to an Either:

```diff
-consume :: Stream -> (String -> IO (Maybe a)) -> IO (Maybe a)
+consume :: Stream -> (String -> IO (Maybe a)) -> IO (Either (Maybe String) a)
```

This allows us to keep track of what the last message from GHCI was so
so that we can report it back to the user. Similarly, the signature
for GhciError was changed:

```diff
-data GhciError = UnexpectedExit String String
+data GhciError = UnexpectedExit String String (Maybe String)
```

So that we can store this information. After that, just change the
error handling to print a Just "..." message.

ghcid now shows something like this on out of memory:

  Command "ghci ..." exited unexpectedly with error message: ghc:
  failed to create OS thread: Cannot allocate memory

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
