### PR TITLE
Restart on file changes detected by --restart=dir/

### DIFF
--- a/ghcid.cabal
+++ b/ghcid.cabal
@@ -30,7 +30,7 @@ library
         filepath,
         time >= 1.5,
         directory >= 1.2,
-        extra >= 1.6.6,
+        extra >= 1.6.20,
         process >= 1.1,
         ansi-terminal,
         cmdargs >= 0.10
@@ -56,7 +56,7 @@ executable ghcid
         directory >= 1.2,
         containers,
         fsnotify,
-        extra >= 1.6.6,
+        extra >= 1.6.20,
         process >= 1.1,
         cmdargs >= 0.10,
         ansi-terminal,

--- a/src/Wait.hs
+++ b/src/Wait.hs
@@ -101,12 +101,12 @@ waitFiles waiter = do
                 WaiterNotify _ kick _ -> do
                     takeMVar kick
                     whenLoud $ outStrLn "%WAITING: Notify signaled"
-            new <- mapM getModTime (map fst files)
+            new <- mapM (getModTime . fst) files
             case [x | (x,t1,t2) <- zip3 files old new, t1 /= t2] of
                 [] -> recheck files new
                 xs -> do
                     let disappeared = [x | (x, Just _, Nothing) <- zip3 files old new]
-                    when (not (null disappeared)) $ do
+                    unless (null disappeared) $ do
                         -- if someone is deleting a needed file, give them some space to put the file back
                         -- typically caused by VIM
                         -- but try not to


### PR DESCRIPTION
This attempts to fix https://github.com/ndmitchell/ghcid/issues/273 by detecting whether any of the triggered paths are subfiles of a directory supplied `--restart`. As a consequence, it would override more specific paths passed to reload. E.g. in:

```
ghcid --reload=dir/path/specific.hs --restart=dir/path
```

`restart` would take precedence over `reload` if `dir/path/specific.hs` changes.