### PR TITLE
Add --target option for specifying argument to `cabal repl`

### DIFF
--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -8,7 +8,6 @@ import Control.Exception
 import System.IO.Error
 import Control.Applicative
 import Control.Monad.Extra
-import qualified Data.Foldable as Foldable
 import Data.List.Extra
 import Data.Maybe
 import Data.Ord
@@ -161,8 +160,7 @@ autoOptions o@Options{..}
               | ".ghci" `elem` files -> f ("ghci":opts) [curdir </> ".ghci"]
               | cabal /= [] ->
                   let useCabal =
-                          let prefix =
-                                  [ "cabal", "repl" ] ++ Foldable.toList target
+                          let prefix = [ "cabal", "repl" ] ++ maybeToList target
                               suffix = map ("--ghc-options=" ++) opts
                           in  prefix ++ suffix
                       useGHCI = "cabal exec -- ghci":opts

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -8,6 +8,7 @@ import Control.Exception
 import System.IO.Error
 import Control.Applicative
 import Control.Monad.Extra
+import qualified Data.Foldable as Foldable
 import Data.List.Extra
 import Data.Maybe
 import Data.Ord
@@ -65,6 +66,7 @@ data Options = Options
     ,color :: ColorMode
     ,setup :: [String]
     ,allow_eval :: Bool
+    ,target :: Maybe String
     }
     deriving (Data,Typeable,Show)
 
@@ -103,6 +105,7 @@ options = cmdArgsMode $ Options
     ,color = Auto &= name "colour" &= name "color" &= opt Always &= typ "always/never/auto" &= help "Color output (defaults to when the terminal supports it)"
     ,setup = [] &= name "setup" &= typ "COMMAND" &= help "Setup commands to pass to ghci on stdin, usually :set <something>"
     ,allow_eval = False &= name "allow-eval" &= help "Execute REPL commands in comments"
+    ,target = Nothing &= typ "TARGET" &= help "Cabal target to build (e.g. lib:foo)"
     } &= verbosity &=
     program "ghcid" &= summary ("Auto reloading GHCi daemon v" ++ showVersion version)
 
@@ -156,7 +159,18 @@ autoOptions o@Options{..}
                                 "stack exec --test --bench -- ghci" : opts
                 in f flags $ stack:cabal
               | ".ghci" `elem` files -> f ("ghci":opts) [curdir </> ".ghci"]
-              | cabal /= [] -> f (if null arguments then "cabal repl":map ("--ghc-options=" ++) opts else "cabal exec -- ghci":opts) cabal
+              | cabal /= [] ->
+                  let useCabal =
+                          let prefix =
+                                  [ "cabal", "repl" ] ++ Foldable.toList target
+
+                              suffix = map ("--ghc-options=" ++) opts
+
+                          in  prefix ++ suffix
+
+                      useGHCI = "cabal exec -- ghci":opts
+
+                  in  f (if null arguments then useCabal else useGHCI) cabal
               | otherwise -> f ("ghci":opts) []
     where
         f c r = o{command = unwords $ c ++ map escape arguments, arguments = [], restart = restart ++ r, run = [], test = run ++ test}

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -160,9 +160,8 @@ autoOptions o@Options{..}
               | ".ghci" `elem` files -> f ("ghci":opts) [curdir </> ".ghci"]
               | cabal /= [] ->
                   let useCabal =
-                          let prefix = [ "cabal", "repl" ] ++ maybeToList target
-                              suffix = map ("--ghc-options=" ++) opts
-                          in  prefix ++ suffix
+                              [ "cabal", "repl" ] ++ maybeToList target
+                          ++  map ("--ghc-options=" ++) opts
                       useGHCI = "cabal exec -- ghci":opts
                   in  f (if null arguments then useCabal else useGHCI) cabal
               | otherwise -> f ("ghci":opts) []

--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -163,13 +163,9 @@ autoOptions o@Options{..}
                   let useCabal =
                           let prefix =
                                   [ "cabal", "repl" ] ++ Foldable.toList target
-
                               suffix = map ("--ghc-options=" ++) opts
-
                           in  prefix ++ suffix
-
                       useGHCI = "cabal exec -- ghci":opts
-
                   in  f (if null arguments then useCabal else useGHCI) cabal
               | otherwise -> f ("ghci":opts) []
     where


### PR DESCRIPTION
90% of the time, when I want to customize `ghcid`'s behavior, it's to specify
an explicit target to `cabal repl`.  Usually I do so by providing
`--command 'cabal repl lib:foo'`, but we can simplify this to
`--target lib:foo` and also take advantage of other useful default
behaviors (like `--ghc-options=-fno-code`)
