### PR TITLE
Fix `--target` to work on `exe:` targets

### DIFF
--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -147,7 +147,8 @@ autoOptions o@Options{..}
         stack <- firstJustM findStack [".",".."] -- stack file might be parent, see #62
 
         let cabal = map (curdir </>) $ filter ((==) ".cabal" . takeExtension) files
-        let opts = ["-fno-code" | null test && null run && not allow_eval] ++ ghciFlagsRequired ++ ghciFlagsUseful
+        let isLib = isPrefixOf "lib:"
+        let opts = ["-fno-code" | null test && null run && not allow_eval && all isLib target] ++ ghciFlagsRequired ++ ghciFlagsUseful
         pure $ case () of
             _ | Just stack <- stack ->
                 let flags = if null arguments then


### PR DESCRIPTION
... by disabling `-fno-code` for those targets

... as caught by @basile-henry in:

https://github.com/ndmitchell/ghcid/pull/302#issuecomment-597015365