### PR TITLE
Add convetional headers for Emacs package

### DIFF
--- a/plugins/emacs/ghcid.el
+++ b/plugins/emacs/ghcid.el
@@ -1,9 +1,13 @@
 ;;; ghcid.el --- Really basic ghcid+stack support in emacs with compilation-mode -*- lexical-binding: t -*-
 
-;; Author: Neil Mitchell <ndmitchell@gmail.com>
-;; Maintainer: Neil Mitchell <ndmitchell@gmail.com>
+;; Author: Matthew Wraith <wraithm@gmail.com>
+;;         Yorick Sijsling
+;; Maintainer: Matthew Wraith <wraithm@gmail.com>
+;;             Yorick Sijsling
+;;             Vasiliy Yorkin <vasiliy.yorkin@gmail.com>
+;;             Neil Mitchell <ndmitchell@gmail.com>
 ;; URL: https://github.com/ndmitchell/ghcid
-;; Version: 0.8.3
+;; Version: 1.0
 ;; Created: 26 Sep 2014
 ;; Keywords: tools, files, Haskell
 

--- a/plugins/emacs/ghcid.el
+++ b/plugins/emacs/ghcid.el
@@ -114,7 +114,7 @@ exactly. See `ghcid-mode'."
 
       (term-exec (ghcid-buffer-name)
            ghcid-process-name
-           "/run/current-system/sw/bin/bash"
+           "/bin/bash"
            nil
            (list "-c" (ghcid-command height)))
 

--- a/plugins/emacs/ghcid.el
+++ b/plugins/emacs/ghcid.el
@@ -1,5 +1,17 @@
-;; Really basic ghcid+stack support in emacs with compilation-mode
+;;; ghcid.el --- Really basic ghcid+stack support in emacs with compilation-mode -*- lexical-binding: t -*-
+
+;; Author: Neil Mitchell <ndmitchell@gmail.com>
+;; Maintainer: Neil Mitchell <ndmitchell@gmail.com>
+;; URL: https://github.com/ndmitchell/ghcid
+;; Version: 0.8.3
+;; Created: 26 Sep 2014
+;; Keywords: tools, files, Haskell
+
+;;; Commentary:
+
 ;; Use M-x ghcid to launch
+
+;;; Code:
 
 (require 'term)
 
@@ -131,3 +143,5 @@ you ran this command from."
 
 
 (provide 'ghcid)
+
+;;; ghcid.el ends here

--- a/plugins/emacs/ghcid.el
+++ b/plugins/emacs/ghcid.el
@@ -110,7 +110,7 @@ exactly. See `ghcid-mode'."
 
       (term-exec (ghcid-buffer-name)
            ghcid-process-name
-           "/bin/bash"
+           "/run/current-system/sw/bin/bash"
            nil
            (list "-c" (ghcid-command height)))
 


### PR DESCRIPTION
This PR adds a few headers for ghcid Emacs package which are required when using tools like [quelpa](https://github.com/quelpa/quelpa). For example, currently if you try to use `quelpa` + `use-package` to load the `ghcid` plugin:
```elisp
(use-package ghcid
  :after (haskell-mode)
  :quelpa
  (ghcid :fetcher url :url "https://raw.githubusercontent.com/ndmitchell/ghcid/master/plugins/emacs/ghcid.el")
  ...
  )
```
it will complain about missing headers:
```sh
Error getting PACKAGE-DESC: (error Package lacks a file header)
```
This PR provides a fix according to
https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html

(I hope that dates and copyrights are correct)