### PR TITLE
`--target` use with Stack

### DIFF
--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -65,7 +65,7 @@ data Options = Options
     ,color :: ColorMode
     ,setup :: [String]
     ,allow_eval :: Bool
-    ,target :: Maybe String
+    ,target :: [String]
     }
     deriving (Data,Typeable,Show)
 
@@ -104,7 +104,7 @@ options = cmdArgsMode $ Options
     ,color = Auto &= name "colour" &= name "color" &= opt Always &= typ "always/never/auto" &= help "Color output (defaults to when the terminal supports it)"
     ,setup = [] &= name "setup" &= typ "COMMAND" &= help "Setup commands to pass to ghci on stdin, usually :set <something>"
     ,allow_eval = False &= name "allow-eval" &= help "Execute REPL commands in comments"
-    ,target = Nothing &= typ "TARGET" &= help "Target Component to build (e.g. lib:foo for Cabal, foo:lib for Stack)"
+    ,target = [] &= typ "TARGET" &= help "Target Component to build (e.g. lib:foo for Cabal, foo:lib for Stack)"
     } &= verbosity &=
     program "ghcid" &= summary ("Auto reloading GHCi daemon v" ++ showVersion version)
 
@@ -157,7 +157,7 @@ autoOptions o@Options{..}
         pure $ case () of
             _ | Just stack <- stackFile ->
                 let flags = if null arguments then
-                                "stack ghci" : maybeToList target ++ "--test --bench" :
+                                "stack ghci" : target ++ "--test --bench" :
                                 ["--no-load" | ".ghci" `elem` files] ++
                                 map ("--ghci-options=" ++) opts
                             else
@@ -165,7 +165,7 @@ autoOptions o@Options{..}
                 in f flags $ stack:cabal
               | ".ghci" `elem` files -> f ("ghci":opts) [curdir </> ".ghci"]
               | cabal /= [] ->
-                  let useCabal = ["cabal","repl"] ++ maybeToList target ++ map ("--repl-options=" ++) opts
+                  let useCabal = ["cabal","repl"] ++ target ++ map ("--repl-options=" ++) opts
                       useGhci = "cabal exec -- ghci":opts
                   in  f (if null arguments then useCabal else useGhci) cabal
               | otherwise -> f ("ghci":opts) []


### PR DESCRIPTION
This PR enables `--target` to be used with stack-based projects. It also allows `--target` to be passed more than once, since `stack` can load multiple components. 

Closes #297 