### PR TITLE
color output as suggested by #75

### DIFF
--- a/plugins/nvim/ftplugin/haskell.vim
+++ b/plugins/nvim/ftplugin/haskell.vim
@@ -335,6 +335,7 @@ function! s:ghcid(...) abort
     silent normal! G
     set norelativenumber
     set nonumber
+    set filetype=haskell
     let s:ghcid_job_id = b:terminal_job_id
   endif
 


### PR DESCRIPTION
Set file type to Haskell to enable syntax highlighting, as suggested by #75. Make this behavior default for vim.
