### PR TITLE
Activate on startup

### DIFF
--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -18,10 +18,7 @@
         "Programming Languages",
         "Linters"
     ],
-    "activationEvents": [
-        "onCommand:extension.startGhcid",
-        "workspaceContains:**/ghcid.txt"
-    ],
+    "activationEvents": ["*"],
     "main": "./out/src/extension",
     "contributes": {
         "commands": [

--- a/plugins/vscode/package.json
+++ b/plugins/vscode/package.json
@@ -18,6 +18,10 @@
         "Programming Languages",
         "Linters"
     ],
+    "//": [
+        "Activate unconditionally on startup to register file watchers.",
+        "See https://github.com/ndmitchell/ghcid/pull/317"
+    ],
     "activationEvents": ["*"],
     "main": "./out/src/extension",
     "contributes": {


### PR DESCRIPTION
I thought `"activationEvents":["workspaceContains"]` would trigger
activation whenever a matching file was added/changed/removed. It turns
out that workspaceContains is only evaluated once on startup:

https://code.visualstudio.com/api/references/activation-events#workspaceContains

cc @ndmitchell 