### PR TITLE
Allow eval multiline commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,14 @@ In general, to use `ghcid`, you first need to get `ghci` working well for you. I
 Using the `ghci` session that `ghcid` manages you can also evaluate expressions:
 
 * You can pass any `ghci` expression with the `--test` flag, e.g. `--test=:main`, which will be run whenever the code is warning free (or pass `--warnings` for when the code is merely error free).
-* If you pass the `--allow-eval` flag then comments in the source files such as `-- $> expr` will run `expr` after loading - see [this blog post](https://jkeuhlen.com/2019/10/19/Compile-Your-Comments-In-Ghcid.html) for more details.
+* If you pass the `--allow-eval` flag then comments in the source files such as `-- $> expr` will run `expr` after loading - see [this blog post](https://jkeuhlen.com/2019/10/19/Compile-Your-Comments-In-Ghcid.html) for more details. Multiline comments are also supported with the following syntax:
+
+      {- $>
+      expr1
+      expr2
+      ...
+      exprN
+      <$ -}
 
 ### FAQ
 

--- a/src/Language/Haskell/Ghcid.hs
+++ b/src/Language/Haskell/Ghcid.hs
@@ -184,6 +184,7 @@ startGhciProcess process echo0 = do
                     writeInp "import qualified System.IO as INTERNAL_GHCID"
                     writeInp ":unset +t +s" -- see https://github.com/ndmitchell/ghcid/issues/162
                     writeInp $ ":set prompt " ++ ghcid_prefix
+                    writeInp $ ":set prompt-cont " ++ ghcid_prefix
 
                     -- failure isn't harmful, so do them one-by-one
                     forM_ (ghciFlagsRequired ++ ghciFlagsRequiredVersioned) $ \flag ->

--- a/src/Session.hs
+++ b/src/Session.hs
@@ -149,7 +149,7 @@ performEvals ghci True reloaded = do
     fmap join $ forM cmds $ \(file, cmds') ->
         forM cmds' $ \(num, cmd) -> do
             ref <- newIORef []
-            execStream ghci (unwords $ lines cmd) $ \_ resp -> modifyIORef ref (resp :)
+            execStream ghci cmd $ \_ resp -> modifyIORef ref (resp :)
             resp <- unlines . reverse <$> readIORef ref
             pure $ Eval $ EvalResult file (num, 1) cmd resp
 
@@ -164,7 +164,7 @@ splitCommands [] = []
 splitCommands ((num, line) : ls)
     | isCommand line =
           let (cmds, xs) = span (isCommand . snd) ls
-           in (num, unlines $ fmap (drop $ length commandPrefix) $ line : fmap snd cmds) : splitCommands xs
+           in (num, unwords $ fmap (drop $ length commandPrefix) $ line : fmap snd cmds) : splitCommands xs
     | otherwise = splitCommands ls
 
 isCommand :: String -> Bool


### PR DESCRIPTION
The idea here is to extend `--allow-eval` to allow comments like 

```haskell
{- $>
data Foo = Bar | Baz
  deriving (Generic, Eq, Ord, Show)
<$ -}
```

to be picked up as commands by ghcid. The effect should be the same as typing

```haskell
:{
data Foo = Bar | Baz
  deriving (Generic, Eq, Ord, Show)
:}
```

in a ghci session.
