### PR TITLE
vim: color with syntax=haskell

### DIFF
--- a/plugins/nvim/ftplugin/haskell.vim
+++ b/plugins/nvim/ftplugin/haskell.vim
@@ -335,7 +335,7 @@ function! s:ghcid(...) abort
     silent normal! G
     set norelativenumber
     set nonumber
-    set filetype=haskell
+    set syntax=haskell
     let s:ghcid_job_id = b:terminal_job_id
   endif
 


### PR DESCRIPTION
`filetype=haskell` breaks `autocmd FileType ghcid`, this pr uses `syntax=haskell` to enable highlighting instead
