### PR TITLE
Add target to status output

### DIFF
--- a/src/Language/Haskell/Ghcid/Util.hs
+++ b/src/Language/Haskell/Ghcid/Util.hs
@@ -7,7 +7,7 @@ module Language.Haskell.Ghcid.Util(
     takeRemainder,
     outStr, outStrLn,
     ignored,
-    allGoodMessage,
+    allGoodMessage, errorMessage, warningMessage,
     getModTime, getModTimeResolution, getShortTime
     ) where
 
@@ -85,8 +85,16 @@ ignored act = do
     waitBarrier bar
 
 -- | The message to show when no errors have been reported
-allGoodMessage :: String
-allGoodMessage = setSGRCode [SetColor Foreground Dull Green] ++  "All good" ++ setSGRCode []
+allGoodMessage :: [String] -> String
+allGoodMessage target = setSGRCode [SetColor Foreground Dull Green] ++ "All good " ++ setSGRCode [] ++ "in " ++ concat target 
+
+-- | The message to show when errors have been reported
+errorMessage :: [String] -> String
+errorMessage target = setSGRCode [SetColor Foreground Dull Red] ++ "Error " ++ setSGRCode [] ++ "in " ++ concat target
+
+-- | The message to show when only warnings have been reported
+warningMessage :: [String] -> String
+warningMessage target = setSGRCode [SetColor Foreground Dull Magenta] ++ "Warning " ++ setSGRCode [] ++ "in " ++ concat target
 
 -- | Given a 'FilePath' return either 'Nothing' (file does not exist) or 'Just' (the modification time)
 getModTime :: FilePath -> IO (Maybe UTCTime)


### PR DESCRIPTION
Howdy, this patch adds the target to the status output.

This is especially useful when one has multiple `ghcid` instances running (e.g. working at the same time on an executable and libraries it depends on.)

I put in a couple extra headings for the errors and warnings to give the target a reasonable place to appear in and I matched GHCi's color scheme for those.

One thing I'm not sure about is what the window title format should be: maybe it's good enough as it is since it shows the project? I also do not have a windows machine to try and get a feel.

Would appreciate feedback!
Thanks.