### PR TITLE
add (require 'compile)

### DIFF
--- a/plugins/emacs/ghcid.el
+++ b/plugins/emacs/ghcid.el
@@ -16,7 +16,7 @@
 ;; Use M-x ghcid to launch
 
 ;;; Code:
-
+(require 'compile)
 (require 'term)
 
 ;; Set ghcid-target to change the stack target


### PR DESCRIPTION
I needed to add (require 'compile) to not get an error of compilation-error-regexp-alist-alist being uninitialized or nil

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
