### PR TITLE
fixing build issue with fsnotify

### DIFF
--- a/ghcid.cabal
+++ b/ghcid.cabal
@@ -89,7 +89,7 @@ test-suite ghcid_test
         directory >= 1.2,
         process,
         containers,
-        fsnotify,
+        fsnotify < 0.4,
         extra >= 1.6.6,
         ansi-terminal,
         terminal-size >= 0.3,


### PR DESCRIPTION
I couldn't build ghcid with the latest versioin of fsnotify (v0.4).

This adds a constraint on the version of fsnotify to get the older version and be able to build ghcid.
