### PR TITLE
Fix crash when modules are renamed or deleted / `withFile: does not exist`

### DIFF
--- a/src/Language/Haskell/Ghcid/Parser.hs
+++ b/src/Language/Haskell/Ghcid/Parser.hs
@@ -64,7 +64,7 @@ parseLoad (map Esc -> xs) = nubOrd $ f xs
 
         -- <no location info>: error:
         f (x:xs)
-            | unescapeE x == "<no location info>: error:"
+            | "<no location info>: error:" `isPrefixOfE` x
             , (xs,rest) <- span leadingWhitespaceE xs
             = Message Error "<unknown>" (0,0) (0,0) (map fromEsc $ x:xs) : f rest
 


### PR DESCRIPTION
With GHC 9.6, renaming or deleting a module while `ghcid` is running will trigger a crash with a confusing error message:

```
Reloading...
  ~/repo/src/MyModule.hs

All good (0 modules, at 12:40:11)

No files loaded, nothing to wait for. Fix the last error and restart.
```

The `unescapeE x == "<no location info>: error:"` check doesn't work with GHC 9.6 because errors have unique numbers attached now:

```
<no location info>: error: [GHC-82272]
    module 'MyCoolModule' cannot be found locally
```

After fixing the message parsing logic, we get another confusing error message:

```
All good (5669 modules, at 14:21:52)
Reloading...
  ~/repo/src/MyCoolModule.hsghcid: ~/repo/<unknown>: withFile: does not exist (No such file or directory)
```

It turns out that `Message`s with `loadFile = "<unknown>"` aren't properly filtered in `loadedModules`:

https://github.com/ndmitchell/ghcid/blob/ac3c2f922f3cd7157f58ee730010e4d478cb3499/src/Session.hs#L85

This PR fixes both issues.