### PR TITLE
Write output of the linter into output file(s)

### DIFF
--- a/src/Ghcid.hs
+++ b/src/Ghcid.hs
@@ -402,7 +402,10 @@ runGhcid session waiter termSize termOutput opts@Options{..} = do
             whenJust lint $ \lintcmd ->
                 unless hasErrors $ do
                     (exitcode, stdout, stderr) <- readCreateProcessWithExitCode (shell . unwords $ lintcmd : map escape touched) ""
-                    unless (exitcode == ExitSuccess) $ outStrLn (stdout ++ stderr)
+                    unless (exitcode == ExitSuccess) $ do
+                        let output = stdout ++ stderr
+                        outStrLn output
+                        forM_ outputfile $ flip writeFile output
 
             reason <- nextWait $ map (,Restart) restart
                               ++ map (,Reload) reload


### PR DESCRIPTION
Output file enables integration with editors to parse compiler error messages and jump to the error location, and there is no reason to not have this convenience with linter.

By the way, thank you for the project. It is awesome. It provides one of the best developer experiences across all tools and all languages I worked with.