### PR TITLE
Add a link to ghcid-error-file.nvim neovim plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Please [report any bugs](https://github.com/ndmitchell/ghcid/issues) you find.
 There are a few plugins that integrate Ghcid into editors, notably:
 
 * [VS Code](plugins/vscode/)
-* [nvim](plugins/nvim/)
+* neovim
+    * [ghcid](plugins/nvim/)
+    * [ghcid-error-file.nvim](https://github.com/jecaro/ghcid-error-file.nvim)
 * [vim](https://github.com/aiya000/vim-ghcid-quickfix)
 * [Emacs](plugins/emacs/)
 


### PR DESCRIPTION
I wrote a new `neovim` plugin for `ghcid`. It would be nice if it were referenced from `ghcid` repo along the other plugins.

Thx for such a great tool btw 